### PR TITLE
fix: remove promote_user_to_admin bypass and make knock auto-invite opt-in

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+synapse-pangea-chat-modules

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -151,6 +151,9 @@ class PangeaChat:
 
         # --- auto_accept_invite config ---
         auto_accept_invite_worker = config.get("auto_accept_invite_worker", None)
+        auto_invite_knocker_enabled = config.get("auto_invite_knocker_enabled", False)
+        if not isinstance(auto_invite_knocker_enabled, bool):
+            raise ValueError('Config "auto_invite_knocker_enabled" must be a boolean')
 
         # --- delete_room config ---
         delete_room_requests_per_burst = config.get(
@@ -213,6 +216,7 @@ class PangeaChat:
             knock_with_code_requests_per_burst=knock_with_code_requests_per_burst,
             knock_with_code_burst_duration_seconds=knock_with_code_burst_duration_seconds,
             auto_accept_invite_worker=auto_accept_invite_worker,
+            auto_invite_knocker_enabled=auto_invite_knocker_enabled,
             delete_room_requests_per_burst=delete_room_requests_per_burst,
             delete_room_burst_duration_seconds=delete_room_burst_duration_seconds,
             limit_user_directory_public_attribute_search_path=limit_user_directory_public_attribute_search_path,

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -43,6 +43,7 @@ class PangeaChatConfig:
 
     # --- auto_accept_invite config ---
     auto_accept_invite_worker: Optional[str] = None
+    auto_invite_knocker_enabled: bool = False
 
     # --- delete_room config ---
     delete_room_requests_per_burst: int = 10


### PR DESCRIPTION
## Summary

Fixes #11 — the `auto_invite_knocker` feature (commit `3c9aa0c`) caused staging Synapse to freeze due to replication stream timeouts and cascading CPU exhaustion.

## Root Cause

`promote_user_to_admin()` bypassed Synapse auth using internal `_persist_events` API, which doesn't participate correctly in the worker replication stream. When the replication stream timed out, all pending `on_new_event` callbacks fired from a broken logging context, causing cascading failure.

## Changes

### 1. Removed `promote_user_to_admin()` entirely
The function used internal Synapse APIs (`_persist_events`, `create_new_client_event` with `requester=None`) to bypass auth checks. This interacted badly with on worker replication. Now, if no local user has sufficient power to invite, `get_inviter_user()` returns `None` gracefully instead of attempting the dangerous bypass.

### 2. Made knock auto-invite opt-in via config
Added `auto_invite_knocker_enabled` config option (default: `false`). The knock → auto-invite flow only runs when explicitly enabled, so staging/production won't be affected unless operators deliberately enable it.

### 3. Added per-room cooldown after failures
If `_auto_invite_knocker` fails for a room, that room enters a 5-minute cooldown period. Subsequent knock events for the same room are skipped during cooldown, preventing the hammering behavior described in the issue.

### 4. Reduced `_retry_make_join` retries (5 → 3)
Reduced max retries from 5 to 3 to limit the compounding effect of replication timeouts. Also improved logging from `logger.info` with f-strings to `logger.warning` with structured args.

### 5. Updated E2E test
`test_knock_auto_invite_admin_left` now verifies that knocking does **not** auto-join the user when no member has invite power (graceful failure), matching the new behavior.

## Config

To enable knock auto-invite (only recommended after further testing):
```yaml
modules:
  - module: synapse_pangea_chat.PangeaChat
    config:
      auto_invite_knocker_enabled: true
```