### PR TITLE
feat: add client-accessible course_activity_summary endpoint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) compos
 | Request Auto Join | `request_auto_join/` | `POST /_synapse/client/unstable/org.pangea/v1/request_auto_join` |
 | Auto Accept Invite | `auto_accept_invite/` | *(third-party rules callback — no HTTP endpoint)* |
 | Delete Room | `delete_room/` | `POST /_synapse/client/pangea/v1/delete_room` |
-| User Activity | `user_activity/` | `GET /_synapse/client/pangea/v1/user_activity`, `GET /_synapse/client/pangea/v1/user_courses`, `GET /_synapse/client/pangea/v1/course_activities` |
+| User Activity | `user_activity/` | `GET /_synapse/client/pangea/v1/user_activity`, `GET /_synapse/client/pangea/v1/user_courses`, `GET /_synapse/client/pangea/v1/course_activities`, `GET /_synapse/client/pangea/v1/course_activity_summary` |
 | Limit User Directory | `limit_user_directory/` | *(spam checker callback — no HTTP endpoint)* |
 
 ## Key Files

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -19,7 +19,12 @@ from synapse_pangea_chat.room_preview import (
     RoomPreview,
     invalidate_room_cache,
 )
-from synapse_pangea_chat.user_activity import CourseActivities, UserActivity, UserCourses
+from synapse_pangea_chat.user_activity import (
+    CourseActivities,
+    CourseActivitySummary,
+    UserActivity,
+    UserCourses,
+)
 
 logger = logging.getLogger(f"synapse.module.{__name__}")
 
@@ -101,6 +106,13 @@ class PangeaChat:
         self._api.register_web_resource(
             path="/_synapse/client/pangea/v1/course_activities",
             resource=self.course_activities_resource,
+        )
+
+        # --- Course Activity Summary (client-accessible) ---
+        self.course_activity_summary_resource = CourseActivitySummary(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/course_activity_summary",
+            resource=self.course_activity_summary_resource,
         )
 
         # --- User Courses ---

--- a/synapse_pangea_chat/user_activity/__init__.py
+++ b/synapse_pangea_chat/user_activity/__init__.py
@@ -1,7 +1,8 @@
 from synapse_pangea_chat.user_activity.user_activity import (
     CourseActivities,
+    CourseActivitySummary,
     UserActivity,
     UserCourses,
 )
 
-__all__ = ["CourseActivities", "UserActivity", "UserCourses"]
+__all__ = ["CourseActivities", "CourseActivitySummary", "UserActivity", "UserCourses"]

--- a/synapse_pangea_chat/user_activity/get_course_activity_summary.py
+++ b/synapse_pangea_chat/user_activity/get_course_activity_summary.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from synapse.storage.databases.main.room import RoomStore
+
+logger = logging.getLogger(
+    "synapse_pangea_chat.user_activity.get_course_activity_summary"
+)
+
+PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE = "pangea.activity_plan"
+PANGEA_COURSE_PLAN_STATE_EVENT_TYPE = "pangea.course_plan"
+
+
+async def get_course_activity_summary(
+    room_store: RoomStore,
+    course_room_id: str,
+) -> Dict[str, Any]:
+    """Return lightweight per-activity metadata for a course.
+
+    Unlike get_course_activities, this returns only the fields needed for
+    topic unlock logic: activity_id, member_count, and number_of_participants.
+    No pagination — course activity counts are bounded (typically <50).
+    """
+
+    # --- 1. Verify the room is a course (has pangea.course_plan state) --------
+    verify_query = """
+    SELECT 1 FROM current_state_events cse
+    WHERE cse.room_id = ? AND cse.type = ?
+    LIMIT 1
+    """
+    verify_rows = await room_store.db_pool.execute(
+        "verify_course_room_summary",
+        verify_query,
+        course_room_id,
+        PANGEA_COURSE_PLAN_STATE_EVENT_TYPE,
+    )
+    if not verify_rows:
+        return {"error": "Room is not a course", "course_room_id": course_room_id}
+
+    # --- 2. Find child activity rooms via m.space.parent + activity_plan ------
+    children_query = """
+    SELECT cse_parent.room_id
+    FROM current_state_events cse_parent
+    INNER JOIN current_state_events cse_activity
+        ON cse_activity.room_id = cse_parent.room_id
+    WHERE cse_parent.type = 'm.space.parent'
+      AND cse_parent.state_key = ?
+      AND cse_activity.type = ?
+    """
+    children_rows = await room_store.db_pool.execute(
+        "get_course_activity_rooms_summary",
+        children_query,
+        course_room_id,
+        PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE,
+    )
+
+    activity_room_ids = [row[0] for row in children_rows]
+    if not activity_room_ids:
+        return {"course_room_id": course_room_id, "activities": []}
+
+    placeholders = ",".join(["?" for _ in activity_room_ids])
+
+    # --- 3. Get activity_id + number_of_participants from state event ---------
+    state_query = f"""
+    SELECT cse.room_id, ej.json
+    FROM current_state_events cse
+    INNER JOIN event_json ej ON ej.event_id = cse.event_id
+    WHERE cse.room_id IN ({placeholders})
+      AND cse.type = ?
+    """
+    state_rows = await room_store.db_pool.execute(
+        "get_course_act_state_summary",
+        state_query,
+        *activity_room_ids,
+        PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE,
+    )
+
+    activity_meta: Dict[str, Dict[str, Any]] = {}
+    for row in state_rows:
+        room_id, json_data = row
+        if isinstance(json_data, str):
+            event_data = json.loads(json_data)
+        else:
+            event_data = json_data
+        content = event_data.get("content", {}) if isinstance(event_data, dict) else {}
+        activity_id: Optional[str] = content.get("activity_id")
+        req = content.get("req", {})
+        number_of_participants: Optional[int] = (
+            req.get("number_of_participants") if isinstance(req, dict) else None
+        )
+        activity_meta[room_id] = {
+            "activity_id": activity_id,
+            "number_of_participants": number_of_participants,
+        }
+
+    # --- 4. Member counts (COUNT instead of full member list) -----------------
+    count_query = f"""
+    SELECT rm.room_id, COUNT(*) AS member_count
+    FROM room_memberships rm
+    INNER JOIN current_state_events cse
+        ON cse.event_id = rm.event_id
+    WHERE rm.room_id IN ({placeholders})
+      AND rm.membership = 'join'
+    GROUP BY rm.room_id
+    """
+    count_rows = await room_store.db_pool.execute(
+        "get_course_act_member_counts", count_query, *activity_room_ids
+    )
+    member_counts: Dict[str, int] = {}
+    for row in count_rows:
+        room_id, count = row
+        member_counts[room_id] = count
+
+    # --- 5. Assemble ----------------------------------------------------------
+    activities: List[Dict[str, Any]] = []
+    for rid in activity_room_ids:
+        meta = activity_meta.get(rid, {})
+        activities.append(
+            {
+                "room_id": rid,
+                "activity_id": meta.get("activity_id"),
+                "member_count": member_counts.get(rid, 0),
+                "number_of_participants": meta.get("number_of_participants"),
+            }
+        )
+
+    return {
+        "course_room_id": course_room_id,
+        "activities": activities,
+    }


### PR DESCRIPTION
## Summary

Adds a new **client-accessible** endpoint that returns lightweight per-activity metadata for a course, enabling the client to determine topic unlock state with a **single Synapse request** instead of N choreo/CMS requests.

## Endpoint

```
GET /_synapse/client/pangea/v1/course_activity_summary?course_room_id=!abc:example.com
```

**Auth**: Matrix bearer token. Requester must be a **joined member** of `course_room_id` (not admin-only).

**Response**:

```json
{
  "course_room_id": "!abc:example.com",
  "activities": [
    {
      "room_id": "!def:example.com",
      "activity_id": "act-123",
      "member_count": 3,
      "number_of_participants": 2
    }
  ]
}
```

| Field | Source |
|-------|--------|
| `room_id` | Room ID of the activity room |
| `activity_id` | From `pangea.activity_plan` state event `content.activity_id` |
| `member_count` | `COUNT(*)` of `join` memberships in the room |
| `number_of_participants` | From `pangea.activity_plan` state event `content.req.number_of_participants` |

## Why

The client currently loads **all** activities across all topics when opening course settings (`loadAllActivities()` → one `POST /choreo/activity_plan/localize` per topic). For a 10-topic course this creates 10 concurrent requests fanning out to CMS, contributing to connection pool exhaustion and 502 errors. The only reason this eager loading exists is to get `numberOfParticipants` per activity for topic unlock logic.

This endpoint provides that data from state events Synapse already has, with a single lightweight query.

## Implementation

- Reuses the query pattern from `get_course_activities.py` (verify course → find child rooms via `m.space.parent` + `pangea.activity_plan`)
- Extracts **both** `activity_id` and `number_of_participants` from the state event JSON
- Uses `COUNT(*)` for member counts instead of full member lists
- Membership-gated (checks requester is joined to the course room) rather than admin-only
- No pagination needed — course activity counts are bounded (typically <50)

## Changes

- **New**: `synapse_pangea_chat/user_activity/get_course_activity_summary.py` — query function
- **New class**: `CourseActivitySummary` in `user_activity.py` — membership-gated Resource
- **Updated**: `__init__.py` files to register and export the endpoint
- **6 E2E tests**: auth (401), missing param (400), non-member (403), success, not-a-course (404), admin-as-member
- **Updated docs**: `user-activity.instructions.md`, `copilot-instructions.md`

## Related

- Closes #18
- Ref pangeachat/client#5758