### PR TITLE
Enable Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## What
Enable Dependabot for pip and github-actions ecosystems.

## Why
Addresses pangeachat/security#34 — zero repos had active Dependabot despite ISP claiming it.

## Testing
No client testing needed — config-only change. GitHub validates the YAML on push.

## Deploy Notes
None