### PR TITLE
Simplify Bandit workflow: console output for consistency

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -10,9 +10,6 @@ jobs:
   bandit:
     name: Bandit (Python)
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -21,13 +18,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Bandit
-        run: pip install bandit[sarif]
+        run: pip install bandit
 
       - name: Run Bandit
-        run: bandit -r synapse_pangea_chat/ -f sarif -o bandit-results.sarif --exit-zero
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: bandit-results.sarif
-          category: bandit
+        run: bandit -r synapse_pangea_chat/ -ll -ii


### PR DESCRIPTION
Match other repos — console output with -ll -ii flags instead of SARIF.