### PR TITLE
feat: add delete_user endpoint to cleanup IDs before deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Unified [Synapse](https://github.com/element-hq/synapse) module that bundles all
 | [Room Code](#room-code)                       | `synapse_pangea_chat/room_code/`            | `POST /_synapse/client/pangea/v1/knock_with_code`         | Secret-code-based room invitations                |
 |                                               |                                             | `GET /_synapse/client/pangea/v1/request_room_code`        | Generate a unique room access code                |
 | [Delete Room](#delete-room)                   | `synapse_pangea_chat/delete_room/`          | `POST /_synapse/client/pangea/v1/delete_room`             | Room deletion for highest-power-level members     |
+| [Delete User](#delete-user)                   | `synapse_pangea_chat/delete_user/`          | `POST /_synapse/client/pangea/v1/delete_user`             | Delete user associations then deactivate account   |
 | [Limit User Directory](#limit-user-directory) | `synapse_pangea_chat/limit_user_directory/` | _(spam checker)_                                          | Filter user directory by public profile attribute |
 
 ## Installation
@@ -47,6 +48,10 @@ modules:
       # --- Delete Room ---
       delete_room_requests_per_burst: 10 # default: 10
       delete_room_burst_duration_seconds: 60 # default: 60
+
+      # --- Delete User ---
+      delete_user_requests_per_burst: 5 # default: 5
+      delete_user_burst_duration_seconds: 60 # default: 60
 
       # --- Limit User Directory (disabled when path is null) ---
       limit_user_directory_public_attribute_search_path: "profile.user_settings.public"
@@ -211,6 +216,31 @@ Expose an endpoint for room admins (members with the highest power level) to kic
 Requester must be a member of the room and have the highest power level.
 
 _Originally: [pangeachat/synapse-delete-room-rest-api](https://github.com/pangeachat/synapse-delete-room-rest-api)_
+
+---
+
+## Delete User
+
+Delete user associations (`external_ids` and local `threepids`) and then deactivate the account with data erasure enabled.
+
+**Route:** `POST /_synapse/client/pangea/v1/delete_user`
+
+**Body (optional):** `{ "user_id": "@user:example.com" }`
+
+- If `user_id` is omitted, the requester is deleted.
+- Server admins may specify another local user ID.
+- Non-admins can only delete themselves.
+
+**Response (200):**
+
+```json
+{
+  "message": "Deleted",
+  "user_id": "@user:example.com",
+  "deleted_external_ids": 1,
+  "deleted_threepids": 1
+}
+```
 
 ---
 

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -7,6 +7,7 @@ from synapse.module_api import ModuleApi
 
 from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.delete_room import DeleteRoom
+from synapse_pangea_chat.delete_user import DeleteUser
 from synapse_pangea_chat.limit_user_directory import LimitUserDirectory
 from synapse_pangea_chat.public_courses import PublicCourses
 from synapse_pangea_chat.room_code import KnockWithCode, RequestRoomCode
@@ -79,6 +80,13 @@ class PangeaChat:
         self._api.register_web_resource(
             path="/_synapse/client/pangea/v1/delete_room",
             resource=self.delete_room_resource,
+        )
+
+        # --- Delete User ---
+        self.delete_user_resource = DeleteUser(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/delete_user",
+            resource=self.delete_user_resource,
         )
 
         # --- User Activity ---
@@ -200,6 +208,12 @@ class PangeaChat:
             "user_activity_burst_duration_seconds", 60
         )
 
+        # --- delete_user config ---
+        delete_user_requests_per_burst = config.get("delete_user_requests_per_burst", 5)
+        delete_user_burst_duration_seconds = config.get(
+            "delete_user_burst_duration_seconds", 60
+        )
+
         # --- limit_user_directory config ---
         limit_user_directory_public_attribute_search_path = config.get(
             "limit_user_directory_public_attribute_search_path", None
@@ -264,6 +278,8 @@ class PangeaChat:
             delete_room_burst_duration_seconds=delete_room_burst_duration_seconds,
             user_activity_requests_per_burst=user_activity_requests_per_burst,
             user_activity_burst_duration_seconds=user_activity_burst_duration_seconds,
+            delete_user_requests_per_burst=delete_user_requests_per_burst,
+            delete_user_burst_duration_seconds=delete_user_burst_duration_seconds,
             limit_user_directory_public_attribute_search_path=limit_user_directory_public_attribute_search_path,
             limit_user_directory_whitelist_requester_id_patterns=limit_user_directory_whitelist_requester_id_patterns,
             limit_user_directory_filter_search_if_missing_public_attribute=limit_user_directory_filter_search_if_missing_public_attribute,

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -48,6 +48,10 @@ class PangeaChatConfig:
     user_activity_requests_per_burst: int = 10
     user_activity_burst_duration_seconds: int = 60
 
+    # --- delete_user config ---
+    delete_user_requests_per_burst: int = 5
+    delete_user_burst_duration_seconds: int = 60
+
     # --- limit_user_directory config ---
     limit_user_directory_public_attribute_search_path: Optional[str] = None
     limit_user_directory_whitelist_requester_id_patterns: List[str] = attr.Factory(list)

--- a/synapse_pangea_chat/delete_user/__init__.py
+++ b/synapse_pangea_chat/delete_user/__init__.py
@@ -1,0 +1,3 @@
+from synapse_pangea_chat.delete_user.delete_user import DeleteUser
+
+__all__ = ["DeleteUser"]

--- a/synapse_pangea_chat/delete_user/delete_user.py
+++ b/synapse_pangea_chat/delete_user/delete_user.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from synapse.api.errors import (
+    AuthError,
+    InvalidClientCredentialsError,
+    InvalidClientTokenError,
+    MissingClientTokenError,
+    SynapseError,
+)
+from synapse.http import server
+from synapse.http.server import respond_with_json
+from synapse.http.site import SynapseRequest
+from synapse.module_api import ModuleApi
+from synapse.types import create_requester
+from twisted.internet import defer
+from twisted.web.resource import Resource
+
+from synapse_pangea_chat.delete_room.extract_body_json import extract_body_json
+from synapse_pangea_chat.delete_user.is_rate_limited import is_rate_limited
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger("synapse.module.synapse_pangea_chat.delete_user")
+
+
+class DeleteUser(Resource):
+    isLeaf = True
+
+    def __init__(self, api: ModuleApi, config: PangeaChatConfig):
+        super().__init__()
+        self._api = api
+        self._config = config
+        self._auth = self._api._hs.get_auth()
+        self._datastores = self._api._hs.get_datastores()
+        self._deactivate_account_handler = (
+            self._api._hs.get_deactivate_account_handler()
+        )
+
+    def render_POST(self, request: SynapseRequest):
+        defer.ensureDeferred(self._async_render_POST(request))
+        return server.NOT_DONE_YET
+
+    async def _async_render_POST(self, request: SynapseRequest):
+        try:
+            requester = await self._auth.get_user_by_req(request)
+            requester_id = requester.user.to_string()
+
+            if is_rate_limited(requester_id, self._config):
+                respond_with_json(
+                    request,
+                    429,
+                    {"error": "Rate limited"},
+                    send_cors=True,
+                )
+                return
+
+            body = await extract_body_json(request)
+            if body is None:
+                body = {}
+            if not isinstance(body, dict):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "Invalid JSON in request body"},
+                    send_cors=True,
+                )
+                return
+
+            target_user_id = body.get("user_id", requester_id)
+            if not isinstance(target_user_id, str) or not target_user_id:
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "Missing or invalid user_id"},
+                    send_cors=True,
+                )
+                return
+
+            if not self._api._hs.is_mine_id(target_user_id):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "Can only delete local users"},
+                    send_cors=True,
+                )
+                return
+
+            is_admin = await self._api.is_user_admin(requester_id)
+            if target_user_id != requester_id and not is_admin:
+                respond_with_json(
+                    request,
+                    403,
+                    {"error": "Forbidden: server admin required"},
+                    send_cors=True,
+                )
+                return
+
+            external_ids = await self._datastores.main.get_external_ids_by_user(
+                target_user_id
+            )
+            for auth_provider, external_id in external_ids:
+                await self._datastores.main.remove_user_external_id(
+                    auth_provider,
+                    external_id,
+                    target_user_id,
+                )
+
+            threepids = await self._datastores.main.user_get_threepids(target_user_id)
+            for threepid in threepids:
+                await self._datastores.main.user_delete_threepid(
+                    target_user_id,
+                    threepid.medium,
+                    threepid.address,
+                )
+
+            await self._deactivate_account_handler.deactivate_account(
+                user_id=target_user_id,
+                erase_data=True,
+                requester=create_requester(target_user_id),
+                by_admin=target_user_id != requester_id,
+            )
+
+            respond_with_json(
+                request,
+                200,
+                {
+                    "message": "Deleted",
+                    "user_id": target_user_id,
+                    "deleted_external_ids": len(external_ids),
+                    "deleted_threepids": len(threepids),
+                },
+                send_cors=True,
+            )
+        except (
+            MissingClientTokenError,
+            InvalidClientTokenError,
+            InvalidClientCredentialsError,
+            AuthError,
+        ) as e:
+            logger.error("Forbidden: %s", e)
+            respond_with_json(
+                request,
+                403,
+                {"error": "Forbidden"},
+                send_cors=True,
+            )
+        except SynapseError as e:
+            logger.error("Synapse error while deleting user: %s", e)
+            respond_with_json(
+                request,
+                e.code,
+                {"error": e.msg},
+                send_cors=True,
+            )
+        except Exception as e:
+            logger.error("Unexpected error: %s", e)
+            respond_with_json(
+                request,
+                500,
+                {"error": "Internal server error"},
+                send_cors=True,
+            )

--- a/synapse_pangea_chat/delete_user/is_rate_limited.py
+++ b/synapse_pangea_chat/delete_user/is_rate_limited.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+import time
+from typing import Dict, List
+
+request_log: Dict[str, List[float]] = {}
+
+
+def is_rate_limited(user_id: str, config: PangeaChatConfig) -> bool:
+    current_time = time.time()
+
+    if user_id not in request_log:
+        request_log[user_id] = []
+
+    request_log[user_id] = [
+        timestamp
+        for timestamp in request_log[user_id]
+        if current_time - timestamp <= config.delete_user_burst_duration_seconds
+    ]
+
+    if len(request_log[user_id]) >= config.delete_user_requests_per_burst:
+        return True
+
+    request_log[user_id].append(current_time)
+
+    return False

--- a/tests/test_delete_user_e2e.py
+++ b/tests/test_delete_user_e2e.py
@@ -1,0 +1,336 @@
+import requests
+import yaml
+from psycopg2 import connect
+
+from .base_e2e import BaseSynapseE2ETest
+
+
+class TestDeleteUserE2E(BaseSynapseE2ETest):
+    def _db_args_from_config(self, config_path: str) -> dict:
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+        database = config.get("database", {})
+        args = database.get("args", {})
+        return args
+
+    def _insert_threepid(self, config_path: str, user_id: str, address: str) -> None:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO user_threepids (medium, address, user_id, validated_at, added_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                ("email", address, user_id, 1, 1),
+            )
+            cursor.close()
+        finally:
+            conn.close()
+
+    def _count_threepids(self, config_path: str, user_id: str) -> int:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) FROM user_threepids WHERE user_id = %s",
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            cursor.close()
+            return row[0] if row else 0
+        finally:
+            conn.close()
+
+    def _insert_external_id(
+        self,
+        config_path: str,
+        user_id: str,
+        auth_provider: str,
+        external_id: str,
+    ) -> None:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO user_external_ids (auth_provider, external_id, user_id)
+                VALUES (%s, %s, %s)
+                """,
+                (auth_provider, external_id, user_id),
+            )
+            cursor.close()
+        finally:
+            conn.close()
+
+    def _count_external_ids(self, config_path: str, user_id: str) -> int:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) FROM user_external_ids WHERE user_id = %s",
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            cursor.close()
+            return row[0] if row else 0
+        finally:
+            conn.close()
+
+    async def test_delete_user_self(self):
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="selfdelete",
+                password="pw1",
+                admin=False,
+            )
+            _, access_token = await self.login_user("selfdelete", "pw1")
+            user_id = "@selfdelete:my.domain.name"
+
+            self._insert_threepid(config_path, user_id, "selfdelete@example.com")
+            self._insert_external_id(
+                config_path,
+                user_id,
+                "oidc",
+                "selfdelete-external-id",
+            )
+            self.assertEqual(self._count_threepids(config_path, user_id), 1)
+            self.assertEqual(self._count_external_ids(config_path, user_id), 1)
+
+            delete_user_url = (
+                "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            )
+            response = requests.post(
+                delete_user_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["message"], "Deleted")
+            self.assertEqual(response.json()["user_id"], user_id)
+            self.assertEqual(response.json()["deleted_threepids"], 1)
+            self.assertEqual(response.json()["deleted_external_ids"], 1)
+            self.assertEqual(self._count_threepids(config_path, user_id), 0)
+            self.assertEqual(self._count_external_ids(config_path, user_id), 0)
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "selfdelete",
+                    "password": "pw1",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_delete_user_admin_can_target_another_user(self):
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="pw1",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="target",
+                password="pw2",
+                admin=False,
+            )
+            target_user_id = "@target:my.domain.name"
+            self._insert_threepid(config_path, target_user_id, "target@example.com")
+            self._insert_external_id(
+                config_path,
+                target_user_id,
+                "oidc",
+                "target-external-id",
+            )
+            self.assertEqual(self._count_threepids(config_path, target_user_id), 1)
+            self.assertEqual(self._count_external_ids(config_path, target_user_id), 1)
+
+            _, admin_token = await self.login_user("admin", "pw1")
+
+            delete_user_url = (
+                "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            )
+            response = requests.post(
+                delete_user_url,
+                json={"user_id": "@target:my.domain.name"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["user_id"], target_user_id)
+            self.assertEqual(response.json()["deleted_threepids"], 1)
+            self.assertEqual(response.json()["deleted_external_ids"], 1)
+            self.assertEqual(self._count_threepids(config_path, target_user_id), 0)
+            self.assertEqual(self._count_external_ids(config_path, target_user_id), 0)
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "target",
+                    "password": "pw2",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_delete_user_rejects_non_local_target(self):
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin2",
+                password="pw1",
+                admin=True,
+            )
+
+            _, admin_token = await self.login_user("admin2", "pw1")
+
+            delete_user_url = (
+                "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            )
+            response = requests.post(
+                delete_user_url,
+                json={"user_id": "@remote:other.domain"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("local users", response.json().get("error", ""))
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_delete_user_non_admin_cannot_target_another_user(self):
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="user1",
+                password="pw1",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="user2",
+                password="pw2",
+                admin=False,
+            )
+
+            _, user1_token = await self.login_user("user1", "pw1")
+
+            delete_user_url = (
+                "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            )
+            response = requests.post(
+                delete_user_url,
+                json={"user_id": "@user2:my.domain.name"},
+                headers={"Authorization": f"Bearer {user1_token}"},
+            )
+
+            self.assertEqual(response.status_code, 403)
+            self.assertIn("server admin required", response.json().get("error", ""))
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )


### PR DESCRIPTION
## Summary
- add POST /_synapse/client/pangea/v1/delete_user endpoint
- default target user to requester; allow admin override via optional user_id
- enforce local-user-only deletion and admin permission checks for cross-user deletion
- remove user_external_ids and user_threepids, then deactivate account with erase_data=true
- add config knobs for delete-user rate limiting
- document endpoint in README
- add E2E tests for self delete, admin-target delete, non-local target rejection, and non-admin targeting rejection
- add DB-level assertions that both user_threepids and user_external_ids are removed

## Testing
- black tests/test_delete_user_e2e.py
- ruff check tests/test_delete_user_e2e.py
- python -m unittest tests.test_delete_user_e2e (passes, 4 tests)

## Client integration guide
1. Call POST /_synapse/client/pangea/v1/delete_user with Matrix access token in Authorization header.
2. For self-delete, send no body (or empty JSON); endpoint infers requester.
3. For admin delete flows, include body with user_id set to the target user.
4. Handle non-200 responses:
   - 400: invalid, missing, or non-local user_id
   - 403: non-admin targeting another user, or auth failure
   - 429: rate limited
5. On 200, treat account as deactivated and clear local session/app state.

## Notes
- .vscode/settings.json was intentionally left uncommitted as local editor config.