### PR TITLE
feat: schedule user deletion with cancel/force and due-time processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ modules:
       # --- Delete User ---
       delete_user_requests_per_burst: 5 # default: 5
       delete_user_burst_duration_seconds: 60 # default: 60
+      delete_user_schedule_delay_seconds: 604800 # default: 7 days
+      delete_user_processor_interval_seconds: 60 # default: 60
 
       # --- Limit User Directory (disabled when path is null) ---
       limit_user_directory_public_attribute_search_path: "profile.user_settings.public"
@@ -221,24 +223,38 @@ _Originally: [pangeachat/synapse-delete-room-rest-api](https://github.com/pangea
 
 ## Delete User
 
-Delete user associations (`external_ids` and local `threepids`) and then deactivate the account with data erasure enabled.
+Schedule user deletion for one week in the future by default. Supports canceling or forcing the scheduled deletion.
 
 **Route:** `POST /_synapse/client/pangea/v1/delete_user`
 
-**Body (optional):** `{ "user_id": "@user:example.com" }`
+**Body (optional):**
+
+```json
+{
+  "action": "schedule|cancel|force",
+  "user_id": "@user:example.com"
+}
+```
 
 - If `user_id` is omitted, the requester is deleted.
 - Server admins may specify another local user ID.
 - Non-admins can only delete themselves.
+- `action` defaults to `schedule`.
+
+Behavior by action:
+
+- `schedule`: Creates/updates a deletion schedule for `now + 7 days` (or configured delay).
+- `cancel`: Cancels an existing schedule.
+- `force`: Immediately executes a previously scheduled deletion.
 
 **Response (200):**
 
 ```json
 {
-  "message": "Deleted",
+  "message": "Delete scheduled",
+  "action": "schedule",
   "user_id": "@user:example.com",
-  "deleted_external_ids": 1,
-  "deleted_threepids": 1
+  "execute_at_ms": 1762790400000
 }
 ```
 

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -213,6 +213,12 @@ class PangeaChat:
         delete_user_burst_duration_seconds = config.get(
             "delete_user_burst_duration_seconds", 60
         )
+        delete_user_schedule_delay_seconds = config.get(
+            "delete_user_schedule_delay_seconds", 7 * 24 * 60 * 60
+        )
+        delete_user_processor_interval_seconds = config.get(
+            "delete_user_processor_interval_seconds", 60
+        )
 
         # --- limit_user_directory config ---
         limit_user_directory_public_attribute_search_path = config.get(
@@ -280,6 +286,8 @@ class PangeaChat:
             user_activity_burst_duration_seconds=user_activity_burst_duration_seconds,
             delete_user_requests_per_burst=delete_user_requests_per_burst,
             delete_user_burst_duration_seconds=delete_user_burst_duration_seconds,
+            delete_user_schedule_delay_seconds=delete_user_schedule_delay_seconds,
+            delete_user_processor_interval_seconds=delete_user_processor_interval_seconds,
             limit_user_directory_public_attribute_search_path=limit_user_directory_public_attribute_search_path,
             limit_user_directory_whitelist_requester_id_patterns=limit_user_directory_whitelist_requester_id_patterns,
             limit_user_directory_filter_search_if_missing_public_attribute=limit_user_directory_filter_search_if_missing_public_attribute,

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -51,6 +51,8 @@ class PangeaChatConfig:
     # --- delete_user config ---
     delete_user_requests_per_burst: int = 5
     delete_user_burst_duration_seconds: int = 60
+    delete_user_schedule_delay_seconds: int = 7 * 24 * 60 * 60
+    delete_user_processor_interval_seconds: int = 60
 
     # --- limit_user_directory config ---
     limit_user_directory_public_attribute_search_path: Optional[str] = None

--- a/synapse_pangea_chat/delete_user/delete_user.py
+++ b/synapse_pangea_chat/delete_user/delete_user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 from synapse.api.errors import (
     AuthError,
@@ -15,6 +15,7 @@ from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
 from synapse.module_api import ModuleApi
 from synapse.types import create_requester
+from synapse.util.duration import Duration
 from twisted.internet import defer
 from twisted.web.resource import Resource
 
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("synapse.module.synapse_pangea_chat.delete_user")
 
+SCHEDULE_TABLE = "pangea_delete_user_schedule"
+VALID_ACTIONS = {"schedule", "cancel", "force"}
+
 
 class DeleteUser(Resource):
     isLeaf = True
@@ -35,9 +39,18 @@ class DeleteUser(Resource):
         self._api = api
         self._config = config
         self._auth = self._api._hs.get_auth()
+        self._clock = self._api._hs.get_clock()
         self._datastores = self._api._hs.get_datastores()
         self._deactivate_account_handler = (
             self._api._hs.get_deactivate_account_handler()
+        )
+        self._schedule_table_ready = False
+
+        self._clock.looping_call(
+            self._api._hs.run_as_background_process,
+            Duration(seconds=self._config.delete_user_processor_interval_seconds),
+            desc="pangea_delete_user_process_schedules",
+            func=self._process_scheduled_deletes,
         )
 
     def render_POST(self, request: SynapseRequest):
@@ -66,6 +79,18 @@ class DeleteUser(Resource):
                     request,
                     400,
                     {"error": "Invalid JSON in request body"},
+                    send_cors=True,
+                )
+                return
+
+            action = body.get("action", "schedule")
+            if not isinstance(action, str) or action not in VALID_ACTIONS:
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": "Invalid action. Must be one of: schedule, cancel, force"
+                    },
                     send_cors=True,
                 )
                 return
@@ -99,39 +124,76 @@ class DeleteUser(Resource):
                 )
                 return
 
-            external_ids = await self._datastores.main.get_external_ids_by_user(
-                target_user_id
-            )
-            for auth_provider, external_id in external_ids:
-                await self._datastores.main.remove_user_external_id(
-                    auth_provider,
-                    external_id,
-                    target_user_id,
-                )
+            await self._ensure_schedule_table()
 
-            threepids = await self._datastores.main.user_get_threepids(target_user_id)
-            for threepid in threepids:
-                await self._datastores.main.user_delete_threepid(
-                    target_user_id,
-                    threepid.medium,
-                    threepid.address,
+            if action == "schedule":
+                now_ms = self._clock.time_msec()
+                execute_at_ms = (
+                    now_ms + self._config.delete_user_schedule_delay_seconds * 1000
                 )
+                await self._upsert_schedule(
+                    user_id=target_user_id,
+                    execute_at_ms=execute_at_ms,
+                    requested_by=requester_id,
+                    requested_by_admin=target_user_id != requester_id,
+                )
+                respond_with_json(
+                    request,
+                    200,
+                    {
+                        "message": "Delete scheduled",
+                        "action": "schedule",
+                        "user_id": target_user_id,
+                        "execute_at_ms": execute_at_ms,
+                    },
+                    send_cors=True,
+                )
+                return
 
-            await self._deactivate_account_handler.deactivate_account(
+            if action == "cancel":
+                canceled = await self._delete_schedule(target_user_id)
+                respond_with_json(
+                    request,
+                    200,
+                    {
+                        "message": (
+                            "Delete schedule canceled"
+                            if canceled
+                            else "No delete schedule found"
+                        ),
+                        "action": "cancel",
+                        "user_id": target_user_id,
+                        "canceled": canceled,
+                    },
+                    send_cors=True,
+                )
+                return
+
+            schedule = await self._get_schedule(target_user_id)
+            if schedule is None:
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "No delete schedule found for user"},
+                    send_cors=True,
+                )
+                return
+
+            delete_result = await self._delete_user_now(
                 user_id=target_user_id,
-                erase_data=True,
-                requester=create_requester(target_user_id),
                 by_admin=target_user_id != requester_id,
             )
+            await self._delete_schedule(target_user_id)
 
             respond_with_json(
                 request,
                 200,
                 {
                     "message": "Deleted",
+                    "action": "force",
                     "user_id": target_user_id,
-                    "deleted_external_ids": len(external_ids),
-                    "deleted_threepids": len(threepids),
+                    "deleted_external_ids": delete_result["deleted_external_ids"],
+                    "deleted_threepids": delete_result["deleted_threepids"],
                 },
                 send_cors=True,
             )
@@ -164,3 +226,183 @@ class DeleteUser(Resource):
                 {"error": "Internal server error"},
                 send_cors=True,
             )
+
+    async def _delete_user_now(self, user_id: str, by_admin: bool) -> Dict[str, int]:
+        external_ids = await self._datastores.main.get_external_ids_by_user(user_id)
+        for auth_provider, external_id in external_ids:
+            await self._datastores.main.remove_user_external_id(
+                auth_provider,
+                external_id,
+                user_id,
+            )
+
+        threepids = await self._datastores.main.user_get_threepids(user_id)
+        for threepid in threepids:
+            await self._datastores.main.user_delete_threepid(
+                user_id,
+                threepid.medium,
+                threepid.address,
+            )
+
+        await self._deactivate_account_handler.deactivate_account(
+            user_id=user_id,
+            erase_data=True,
+            requester=create_requester(user_id),
+            by_admin=by_admin,
+        )
+
+        return {
+            "deleted_external_ids": len(external_ids),
+            "deleted_threepids": len(threepids),
+        }
+
+    async def _ensure_schedule_table(self) -> None:
+        if self._schedule_table_ready:
+            return
+
+        def _create_table(txn: Any) -> None:
+            txn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {SCHEDULE_TABLE} (
+                    user_id TEXT PRIMARY KEY,
+                    execute_at_ms BIGINT NOT NULL,
+                    requested_at_ms BIGINT NOT NULL,
+                    requested_by TEXT NOT NULL,
+                    requested_by_admin BOOLEAN NOT NULL DEFAULT FALSE
+                )
+                """
+            )
+            txn.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {SCHEDULE_TABLE}_execute_at_idx
+                ON {SCHEDULE_TABLE}(execute_at_ms)
+                """
+            )
+
+        await self._datastores.main.db_pool.runInteraction(
+            "pangea_delete_user_create_schedule_table",
+            _create_table,
+        )
+        self._schedule_table_ready = True
+
+    async def _upsert_schedule(
+        self,
+        user_id: str,
+        execute_at_ms: int,
+        requested_by: str,
+        requested_by_admin: bool,
+    ) -> None:
+        def _upsert(txn: Any) -> None:
+            txn.execute(
+                f"""
+                INSERT INTO {SCHEDULE_TABLE}
+                    (user_id, execute_at_ms, requested_at_ms, requested_by, requested_by_admin)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (user_id)
+                DO UPDATE SET
+                    execute_at_ms = EXCLUDED.execute_at_ms,
+                    requested_at_ms = EXCLUDED.requested_at_ms,
+                    requested_by = EXCLUDED.requested_by,
+                    requested_by_admin = EXCLUDED.requested_by_admin
+                """,
+                (
+                    user_id,
+                    execute_at_ms,
+                    self._clock.time_msec(),
+                    requested_by,
+                    requested_by_admin,
+                ),
+            )
+
+        await self._datastores.main.db_pool.runInteraction(
+            "pangea_delete_user_upsert_schedule",
+            _upsert,
+        )
+
+    async def _delete_schedule(self, user_id: str) -> bool:
+        def _delete(txn: Any) -> bool:
+            txn.execute(
+                f"DELETE FROM {SCHEDULE_TABLE} WHERE user_id = %s",
+                (user_id,),
+            )
+            return bool(txn.rowcount)
+
+        return await self._datastores.main.db_pool.runInteraction(
+            "pangea_delete_user_delete_schedule",
+            _delete,
+        )
+
+    async def _get_schedule(self, user_id: str) -> Dict[str, Any] | None:
+        def _get(txn: Any) -> Dict[str, Any] | None:
+            txn.execute(
+                f"""
+                SELECT user_id, execute_at_ms, requested_at_ms, requested_by, requested_by_admin
+                FROM {SCHEDULE_TABLE}
+                WHERE user_id = %s
+                """,
+                (user_id,),
+            )
+            row = txn.fetchone()
+            if row is None:
+                return None
+            return {
+                "user_id": row[0],
+                "execute_at_ms": row[1],
+                "requested_at_ms": row[2],
+                "requested_by": row[3],
+                "requested_by_admin": row[4],
+            }
+
+        return await self._datastores.main.db_pool.runInteraction(
+            "pangea_delete_user_get_schedule",
+            _get,
+        )
+
+    async def _claim_due_schedules(self, now_ms: int) -> list[Dict[str, Any]]:
+        def _claim(txn: Any) -> list[Dict[str, Any]]:
+            txn.execute(
+                f"""
+                DELETE FROM {SCHEDULE_TABLE}
+                WHERE execute_at_ms <= %s
+                RETURNING user_id, requested_by_admin
+                """,
+                (now_ms,),
+            )
+            rows = txn.fetchall()
+            return [
+                {"user_id": row[0], "requested_by_admin": bool(row[1])} for row in rows
+            ]
+
+        return await self._datastores.main.db_pool.runInteraction(
+            "pangea_delete_user_claim_due_schedules",
+            _claim,
+        )
+
+    async def _process_scheduled_deletes(self) -> None:
+        await self._ensure_schedule_table()
+        now_ms = self._clock.time_msec()
+        due_schedules = await self._claim_due_schedules(now_ms)
+
+        for schedule in due_schedules:
+            user_id = schedule["user_id"]
+            try:
+                await self._delete_user_now(
+                    user_id=user_id,
+                    by_admin=bool(schedule["requested_by_admin"]),
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to process scheduled delete for %s: %s",
+                    user_id,
+                    e,
+                )
+                retry_at_ms = (
+                    self._clock.time_msec()
+                    + self._config.delete_user_processor_interval_seconds * 1000
+                )
+                await self._upsert_schedule(
+                    user_id=user_id,
+                    execute_at_ms=retry_at_ms,
+                    requested_by=user_id,
+                    requested_by_admin=bool(schedule["requested_by_admin"]),
+                )

--- a/tests/test_delete_user_e2e.py
+++ b/tests/test_delete_user_e2e.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import requests
 import yaml
 from psycopg2 import connect
@@ -6,6 +8,8 @@ from .base_e2e import BaseSynapseE2ETest
 
 
 class TestDeleteUserE2E(BaseSynapseE2ETest):
+    _SCHEDULE_TABLE = "pangea_delete_user_schedule"
+
     def _db_args_from_config(self, config_path: str) -> dict:
         with open(config_path, "r", encoding="utf-8") as config_file:
             config = yaml.safe_load(config_file)
@@ -83,7 +87,22 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
         finally:
             conn.close()
 
-    async def test_delete_user_self(self):
+    def _count_schedules(self, config_path: str, user_id: str) -> int:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self._SCHEDULE_TABLE} WHERE user_id = %s",
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            cursor.close()
+            return row[0] if row else 0
+        finally:
+            conn.close()
+
+    async def test_delete_user_self_schedule_then_force(self):
         postgres = None
         synapse_dir = None
         server_process = None
@@ -129,14 +148,36 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json()["message"], "Deleted")
+            self.assertEqual(response.json()["message"], "Delete scheduled")
+            self.assertEqual(response.json()["action"], "schedule")
             self.assertEqual(response.json()["user_id"], user_id)
-            self.assertEqual(response.json()["deleted_threepids"], 1)
-            self.assertEqual(response.json()["deleted_external_ids"], 1)
-            self.assertEqual(self._count_threepids(config_path, user_id), 0)
-            self.assertEqual(self._count_external_ids(config_path, user_id), 0)
+            self.assertEqual(self._count_schedules(config_path, user_id), 1)
 
             login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "selfdelete",
+                    "password": "pw1",
+                },
+            )
+            self.assertEqual(login_response.status_code, 200)
+
+            force_response = requests.post(
+                delete_user_url,
+                json={"action": "force"},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(force_response.status_code, 200)
+            self.assertEqual(force_response.json()["message"], "Deleted")
+            self.assertEqual(force_response.json()["action"], "force")
+            self.assertEqual(force_response.json()["deleted_threepids"], 1)
+            self.assertEqual(force_response.json()["deleted_external_ids"], 1)
+            self.assertEqual(self._count_threepids(config_path, user_id), 0)
+            self.assertEqual(self._count_external_ids(config_path, user_id), 0)
+            self.assertEqual(self._count_schedules(config_path, user_id), 0)
+
             login_response = requests.post(
                 login_url,
                 json={
@@ -155,7 +196,7 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
                 postgres=postgres,
             )
 
-    async def test_delete_user_admin_can_target_another_user(self):
+    async def test_delete_user_admin_can_cancel_and_force_target_schedule(self):
         postgres = None
         synapse_dir = None
         server_process = None
@@ -209,11 +250,48 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
             )
 
             self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["message"], "Delete scheduled")
+            self.assertEqual(response.json()["action"], "schedule")
             self.assertEqual(response.json()["user_id"], target_user_id)
-            self.assertEqual(response.json()["deleted_threepids"], 1)
-            self.assertEqual(response.json()["deleted_external_ids"], 1)
+            self.assertEqual(self._count_schedules(config_path, target_user_id), 1)
+
+            cancel_response = requests.post(
+                delete_user_url,
+                json={"action": "cancel", "user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            self.assertEqual(cancel_response.status_code, 200)
+            self.assertEqual(cancel_response.json()["action"], "cancel")
+            self.assertTrue(cancel_response.json()["canceled"])
+            self.assertEqual(self._count_schedules(config_path, target_user_id), 0)
+
+            force_without_schedule_response = requests.post(
+                delete_user_url,
+                json={"action": "force", "user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            self.assertEqual(force_without_schedule_response.status_code, 400)
+
+            reschedule_response = requests.post(
+                delete_user_url,
+                json={"user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            self.assertEqual(reschedule_response.status_code, 200)
+            self.assertEqual(self._count_schedules(config_path, target_user_id), 1)
+
+            force_response = requests.post(
+                delete_user_url,
+                json={"action": "force", "user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            self.assertEqual(force_response.status_code, 200)
+            self.assertEqual(force_response.json()["action"], "force")
+            self.assertEqual(force_response.json()["deleted_threepids"], 1)
+            self.assertEqual(force_response.json()["deleted_external_ids"], 1)
             self.assertEqual(self._count_threepids(config_path, target_user_id), 0)
             self.assertEqual(self._count_external_ids(config_path, target_user_id), 0)
+            self.assertEqual(self._count_schedules(config_path, target_user_id), 0)
 
             login_url = "http://localhost:8008/_matrix/client/v3/login"
             login_response = requests.post(
@@ -326,6 +404,84 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
 
             self.assertEqual(response.status_code, 403)
             self.assertIn("server admin required", response.json().get("error", ""))
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_scheduled_delete_executes_with_short_config_delay(self):
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "delete_user_schedule_delay_seconds": 3,
+                    "delete_user_processor_interval_seconds": 1,
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="scheduleduser",
+                password="pw1",
+                admin=False,
+            )
+            user_id = "@scheduleduser:my.domain.name"
+            _, access_token = await self.login_user("scheduleduser", "pw1")
+
+            self._insert_threepid(config_path, user_id, "scheduled@example.com")
+            self._insert_external_id(
+                config_path,
+                user_id,
+                "oidc",
+                "scheduled-external-id",
+            )
+            self.assertEqual(self._count_threepids(config_path, user_id), 1)
+            self.assertEqual(self._count_external_ids(config_path, user_id), 1)
+
+            delete_user_url = (
+                "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            )
+            schedule_response = requests.post(
+                delete_user_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(schedule_response.status_code, 200)
+            self.assertEqual(schedule_response.json()["action"], "schedule")
+            self.assertEqual(self._count_schedules(config_path, user_id), 1)
+
+            await asyncio.sleep(6)
+
+            self.assertEqual(self._count_threepids(config_path, user_id), 0)
+            self.assertEqual(self._count_external_ids(config_path, user_id), 0)
+            self.assertEqual(self._count_schedules(config_path, user_id), 0)
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "scheduleduser",
+                    "password": "pw1",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
         finally:
             self.stop_synapse(
                 server_process=server_process,


### PR DESCRIPTION
## Summary
- change delete flow to schedule by default instead of immediate deletion
- add action support on `POST /_synapse/client/pangea/v1/delete_user`:
  - `schedule` (default): schedule deletion
  - `cancel`: cancel scheduled deletion
  - `force`: execute a pending schedule immediately
- add persistent schedule storage table and background processor that executes due schedules
- keep admin targeting rules (self by default, admin can target another local user)
- keep cleanup behavior (remove `user_threepids` and `user_external_ids`) before deactivation

## Configuration
- add `delete_user_schedule_delay_seconds` (default 7 days)
- add `delete_user_processor_interval_seconds` (processor poll interval)

## Tests
- update E2E coverage for schedule/cancel/force flows
- add E2E test that configures delay to 3 seconds and verifies scheduled deletion executes automatically (without force)
- run:
  - `black tests/test_delete_user_e2e.py`
  - `ruff check --fix tests/test_delete_user_e2e.py`
  - `python -m unittest tests.test_delete_user_e2e`

## Notes
- README updated to document new actions and schedule-based behavior.