### PR TITLE
feat: add language/CEFR filtering and CMS metadata to public_courses endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ modules:
       public_courses_burst_duration_seconds: 120 # default: 120
       public_courses_requests_per_burst: 120 # default: 120
       course_plan_state_event_type: "pangea.course_plan" # default: null (falls back to pangea.course_plan)
+      public_courses_cms_cache_ttl_seconds: 5 # default: 5s — short burst cache; refreshes quickly
 
       # --- Room Preview ---
       room_preview_state_event_types: # additional state event types to expose
@@ -78,10 +79,15 @@ Requires a valid Matrix access token; unauthenticated calls return `401 M_UNAUTH
 
 ### Query Parameters
 
-| Name    | Type    | Default | Description                                  |
-| ------- | ------- | ------- | -------------------------------------------- |
-| `limit` | integer | `10`    | Maximum number of courses to return          |
-| `since` | string  | `None`  | Pagination token returned by a previous call |
+| Name                       | Type    | Default | Description                                                              |
+| -------------------------- | ------- | ------- | ------------------------------------------------------------------------ |
+| `limit`                    | integer | `10`    | Maximum number of courses to return                                      |
+| `since`                    | string  | `None`  | Pagination token returned by a previous call                             |
+| `target_language`          | string  | `None`  | Filter by target language (CMS `l2` field, e.g. `es`)                    |
+| `language_of_instructions` | string  | `None`  | Filter by language of instructions (CMS `originalL1` field, e.g. `en`)   |
+| `cefr_level`               | string  | `None`  | Filter by CEFR level (CMS `cefrLevel` field, e.g. `A1`, `B2`)           |
+
+When any filter parameter is provided, the endpoint queries Payload CMS to match course plans against the filters. This requires `cms_base_url` and `cms_service_api_key` to be configured. If CMS is missing/misconfigured or unavailable, the endpoint falls back to the previous unfiltered behavior.
 
 ### Response
 
@@ -98,14 +104,20 @@ Requires a valid Matrix access token; unauthenticated calls return `401 M_UNAUTH
       "world_readable": false,
       "guest_can_join": false,
       "join_rule": null,
-      "room_type": null
+      "room_type": null,
+      "target_language": "es",
+      "language_of_instructions": "en",
+      "cefr_level": "A1"
     }
   ],
+  "filtering_warning": "",
   "next_batch": "10",
   "prev_batch": null,
   "total_room_count_estimate": 23
 }
 ```
+
+`filtering_warning` is empty when filtering behavior succeeded (or no filters were requested). If language filters were requested but CMS is unavailable/misconfigured, the endpoint still returns normal unfiltered results and sets `filtering_warning` to a non-empty message.
 
 ### Room Selection Criteria
 
@@ -301,6 +313,7 @@ synapse_pangea_chat/
 ├── config.py                    # Unified PangeaChatConfig
 ├── public_courses.py            # Public courses endpoint
 ├── get_public_courses.py        # Public courses query logic
+├── course_metadata_cache.py     # CMS language metadata cache
 ├── is_rate_limited.py           # Public courses rate limiter
 ├── types.py                     # Shared types
 ├── room_preview/                # Room preview module

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -197,6 +197,17 @@ class PangeaChat:
 
         course_plan_state_event_type = config.get("course_plan_state_event_type", None)
 
+        public_courses_cms_cache_ttl_seconds = config.get(
+            "public_courses_cms_cache_ttl_seconds", 5
+        )
+        if (
+            not isinstance(public_courses_cms_cache_ttl_seconds, int)
+            or public_courses_cms_cache_ttl_seconds < 1
+        ):
+            raise ValueError(
+                "public_courses_cms_cache_ttl_seconds must be an integer >= 1"
+            )
+
         # --- room_preview config ---
         room_preview_state_event_types = config.get(
             "room_preview_state_event_types", ["p.room_summary"]
@@ -342,6 +353,7 @@ class PangeaChat:
             public_courses_burst_duration_seconds=public_courses_burst_duration_seconds,
             public_courses_requests_per_burst=public_courses_requests_per_burst,
             course_plan_state_event_type=course_plan_state_event_type,
+            public_courses_cms_cache_ttl_seconds=public_courses_cms_cache_ttl_seconds,
             room_preview_state_event_types=all_event_types,
             room_preview_burst_duration_seconds=room_preview_burst_duration_seconds,
             room_preview_requests_per_burst=room_preview_requests_per_burst,

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -22,6 +22,7 @@ class PangeaChatConfig:
     public_courses_burst_duration_seconds: int = 120
     public_courses_requests_per_burst: int = 120
     course_plan_state_event_type: Optional[str] = None
+    public_courses_cms_cache_ttl_seconds: int = 5
 
     # --- room_preview config ---
     room_preview_state_event_types: List[str] = attr.Factory(list)

--- a/synapse_pangea_chat/public_courses/course_metadata_cache.py
+++ b/synapse_pangea_chat/public_courses/course_metadata_cache.py
@@ -1,0 +1,198 @@
+"""Cache for CMS course plan metadata (language, CEFR level).
+
+Fetches course plan data from Payload CMS and caches per-UUID with a
+configurable TTL.  Two entry points:
+
+* ``get_course_metadata`` – unfiltered lookup for a set of UUIDs
+* ``get_filtered_course_ids`` – passes client-side filters (l2, l1,
+  cefr_level) directly to CMS ``where`` clauses so only matching
+  course plans are returned
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple, TypedDict
+from urllib.parse import urlencode
+
+logger = logging.getLogger("synapse_pangea_chat.course_metadata_cache")
+
+
+class FilteredCourseMetadataLookupError(RuntimeError):
+    """Raised when filtered CMS metadata lookup fails."""
+
+
+class CourseMeta(TypedDict):
+    l2: str
+    l1: str
+    cefr_level: str
+
+
+# Per-UUID in-memory cache: {uuid: (CourseMeta, timestamp)}
+_meta_cache: Dict[str, Tuple[CourseMeta, float]] = {}
+_DEFAULT_TTL_SECONDS = 5  # short burst cache; refresh frequently
+
+
+def _is_fresh(timestamp: float, ttl: int) -> bool:
+    return time.time() - timestamp < ttl
+
+
+def _store(uuid: str, meta: CourseMeta) -> None:
+    _meta_cache[uuid] = (meta, time.time())
+
+
+def _parse_docs(docs: List[Dict[str, Any]]) -> Dict[str, CourseMeta]:
+    result: Dict[str, CourseMeta] = {}
+    for doc in docs:
+        uuid = doc.get("id")
+        if not uuid:
+            continue
+        meta = CourseMeta(
+            l2=doc.get("l2", ""),
+            l1=doc.get("originalL1", ""),
+            cefr_level=doc.get("cefrLevel", ""),
+        )
+        result[str(uuid)] = meta
+        _store(str(uuid), meta)
+    return result
+
+
+async def _cms_get(
+    cms_base_url: str,
+    cms_api_key: str,
+    query_params: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Execute a GET against ``/api/course-plans`` with *query_params*."""
+    from twisted.internet import reactor
+    from twisted.web.client import Agent, readBody
+    from twisted.web.http_headers import Headers
+
+    agent = Agent(reactor)
+
+    qs = urlencode(query_params, doseq=False)
+    url = f"{cms_base_url}/api/course-plans?{qs}"
+
+    response = await agent.request(
+        b"GET",
+        url.encode("utf-8"),
+        Headers(
+            {
+                b"Authorization": [f"users API-Key {cms_api_key}".encode("utf-8")],
+            }
+        ),
+    )
+
+    body = await readBody(response)
+    if response.code >= 400:
+        raise RuntimeError(
+            f"CMS course-plans query failed ({response.code}): "
+            f"{body.decode('utf-8', errors='replace')}"
+        )
+
+    data = json.loads(body)
+    return data.get("docs", [])
+
+
+def _build_where_params(
+    course_uuids: List[str],
+    target_language: Optional[str] = None,
+    language_of_instructions: Optional[str] = None,
+    cefr_level: Optional[str] = None,
+) -> Dict[str, str]:
+    """Build Payload CMS ``where`` query parameters."""
+    params: Dict[str, str] = {
+        "where[id][in]": ",".join(course_uuids),
+        "limit": str(len(course_uuids)),
+        "depth": "0",
+    }
+    if target_language:
+        params["where[l2][equals]"] = target_language
+    if language_of_instructions:
+        params["where[originalL1][equals]"] = language_of_instructions
+    if cefr_level:
+        params["where[cefrLevel][equals]"] = cefr_level
+    return params
+
+
+async def get_course_metadata(
+    course_uuids: List[str],
+    cms_base_url: str,
+    cms_api_key: str,
+    cache_ttl: int = _DEFAULT_TTL_SECONDS,
+) -> Dict[str, CourseMeta]:
+    """Return metadata for *course_uuids*, using cache where possible.
+
+    UUIDs with a fresh cache entry are served from memory; only stale /
+    missing UUIDs are fetched from CMS in a single request.
+    """
+    if not course_uuids:
+        return {}
+
+    result: Dict[str, CourseMeta] = {}
+    to_fetch: List[str] = []
+
+    for uuid in course_uuids:
+        cached = _meta_cache.get(uuid)
+        if cached and _is_fresh(cached[1], cache_ttl):
+            result[uuid] = cached[0]
+        else:
+            to_fetch.append(uuid)
+
+    if not to_fetch:
+        return result
+
+    try:
+        params = _build_where_params(to_fetch)
+        docs = await _cms_get(cms_base_url, cms_api_key, params)
+        fetched = _parse_docs(docs)
+        result.update(fetched)
+    except Exception:
+        logger.warning(
+            "Failed to fetch course metadata from CMS; returning stale/partial cache",
+            exc_info=True,
+        )
+        # Fall back to stale cache entries if available
+        for uuid in to_fetch:
+            stale = _meta_cache.get(uuid)
+            if stale:
+                result[uuid] = stale[0]
+
+    return result
+
+
+async def get_filtered_course_ids(
+    course_uuids: List[str],
+    cms_base_url: str,
+    cms_api_key: str,
+    target_language: Optional[str] = None,
+    language_of_instructions: Optional[str] = None,
+    cefr_level: Optional[str] = None,
+) -> Dict[str, CourseMeta]:
+    """Return metadata only for courses matching the given filters.
+
+    Delegates filtering to CMS via ``where`` clauses so only matching
+    documents are returned.  Results are cached per-UUID for later
+    unfiltered lookups.
+    """
+    if not course_uuids:
+        return {}
+
+    try:
+        params = _build_where_params(
+            course_uuids,
+            target_language=target_language,
+            language_of_instructions=language_of_instructions,
+            cefr_level=cefr_level,
+        )
+        docs = await _cms_get(cms_base_url, cms_api_key, params)
+        return _parse_docs(docs)
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch filtered course metadata from CMS",
+            exc_info=True,
+        )
+        raise FilteredCourseMetadataLookupError(
+            "Filtered CMS course metadata lookup failed"
+        ) from exc

--- a/synapse_pangea_chat/public_courses/get_public_courses.py
+++ b/synapse_pangea_chat/public_courses/get_public_courses.py
@@ -7,7 +7,17 @@ from synapse.api.constants import HistoryVisibility
 from synapse.storage.databases.main.room import RoomStore
 
 from synapse_pangea_chat.config import PangeaChatConfig
-from synapse_pangea_chat.public_courses.types import Course, PublicCoursesResponse
+from synapse_pangea_chat.public_courses.course_metadata_cache import (
+    CourseMeta,
+    FilteredCourseMetadataLookupError,
+    get_course_metadata,
+    get_filtered_course_ids,
+)
+from synapse_pangea_chat.public_courses.types import (
+    Course,
+    CourseFilters,
+    PublicCoursesResponse,
+)
 
 # In-memory cache for course preview data
 # Structure: {room_id: (data, timestamp)}
@@ -35,6 +45,10 @@ RESPONSE_STATE_EVENTS: Tuple[str, ...] = (
 )
 
 DEFAULT_REQUIRED_COURSE_STATE_EVENT_TYPE = "pangea.course_plan"
+
+_FILTERING_WARNING_NONE = ""
+_FILTERING_WARNING_CMS_NOT_CONFIGURED = "Language filters could not be applied: CMS is not configured; returned unfiltered results."
+_FILTERING_WARNING_CMS_LOOKUP_FAILED = "Language filters could not be applied: CMS lookup failed; returned unfiltered results."
 
 
 def _is_cache_valid(timestamp: float) -> bool:
@@ -99,8 +113,11 @@ async def get_public_courses(
     config: PangeaChatConfig,
     limit: int,
     since: Optional[str],
+    filters: Optional[CourseFilters] = None,
 ) -> PublicCoursesResponse:
     logger.debug("Executing public courses query")
+
+    has_filters = bool(filters)
 
     # Clean up expired cache entries periodically
     _cleanup_expired_cache()
@@ -159,55 +176,50 @@ WHERE se.type = ?
     if total_room_count == 0:
         return PublicCoursesResponse(
             chunk=[],
+            filtering_warning=_FILTERING_WARNING_NONE,
             next_batch=None,
             prev_batch=None,
             total_room_count_estimate=0,
         )
 
-    overfetch_limit = limit + 1
-
-    room_ids_query = """
-SELECT room_id FROM (
-    SELECT DISTINCT se.room_id AS room_id
-    FROM state_events se
-    INNER JOIN rooms r ON r.room_id = se.room_id
-    WHERE se.type = ?
-      AND r.is_public = 't'
-) room_ids
-ORDER BY room_id
-OFFSET ?
-LIMIT ?
-    """
-
-    room_rows = await room_store.db_pool.execute(
-        "get_public_courses_room_ids",
-        room_ids_query,
-        required_course_event_type,
-        start_index,
-        overfetch_limit,
-    )
-
-    if not room_rows:
-        # No rooms in this window; compute prev token if applicable and return empty chunk
-        prev_batch = None if start_index <= 0 else str(max(0, start_index - limit))
-        return PublicCoursesResponse(
-            chunk=[],
-            next_batch=None,
-            prev_batch=prev_batch,
-            total_room_count_estimate=total_room_count,
+    if has_filters:
+        return await _get_filtered_public_courses(
+            room_store,
+            config,
+            limit,
+            start_index,
+            total_room_count,
+            required_course_event_type,
+            event_types_with_required,
+            filters,  # type: ignore[arg-type]
         )
 
-    room_ids = [row[0] for row in room_rows]
+    return await _get_unfiltered_public_courses(
+        room_store,
+        config,
+        limit,
+        start_index,
+        total_room_count,
+        required_course_event_type,
+        event_types_with_required,
+    )
 
-    has_next = len(room_ids) > limit
-    display_room_ids = room_ids[:limit]
 
-    courses: List[Course] = []
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
+
+async def _fetch_room_state(
+    room_store: RoomStore,
+    room_ids: List[str],
+    event_types_with_required: List[str],
+) -> Dict[str, RoomStateMap]:
+    """Fetch state events for *room_ids*, using the in-memory cache."""
     rooms_data: Dict[str, RoomStateMap] = {}
     rooms_to_fetch: List[str] = []
 
-    for room_id in display_room_ids:
+    for room_id in room_ids:
         cached = _get_cached_room(room_id)
         if cached is not None:
             rooms_data[room_id] = cached
@@ -262,8 +274,18 @@ ORDER BY e.room_id, e.type, e.state_key, e.origin_server_ts DESC
             rooms_data[room_id] = room_state
             _cache_room_data(room_id, room_state)
 
-    # Fetch room stats and metadata for all display rooms
-    room_stats_placeholders = ",".join(["?" for _ in display_room_ids])
+    return rooms_data
+
+
+async def _fetch_room_stats(
+    room_store: RoomStore,
+    room_ids: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Fetch room stats for *room_ids*."""
+    if not room_ids:
+        return {}
+
+    room_stats_placeholders = ",".join(["?" for _ in room_ids])
     room_stats_query = f"""
 SELECT
     room_id,
@@ -280,84 +302,195 @@ WHERE room_id IN ({room_stats_placeholders})
     room_stats_rows = await room_store.db_pool.execute(
         "get_public_courses_room_stats",
         room_stats_query,
-        *display_room_ids,
+        *room_ids,
     )
 
     room_stats: Dict[str, Dict[str, Any]] = {}
     for row in room_stats_rows:
         (
-            room_id,
+            rid,
             history_visibility,
             guest_access,
             join_rules,
             room_type,
             joined_members,
         ) = row
-        room_stats[room_id] = {
+        room_stats[rid] = {
             "history_visibility": history_visibility,
             "guest_access": guest_access,
             "join_rules": join_rules,
             "room_type": room_type,
             "joined_members": joined_members,
         }
+    return room_stats
 
+
+def _build_course(
+    room_id: str,
+    room_data: RoomStateMap,
+    required_course_event_type: str,
+    stats: Dict[str, Any],
+    meta: Optional[CourseMeta] = None,
+) -> Optional[Course]:
+    """Build a single Course dict from room state + optional CMS metadata."""
+    course_event_state = room_data.get(required_course_event_type)
+    if not course_event_state:
+        return None
+
+    name = None
+    topic = None
+    avatar_url = None
+    canonical_alias = None
+
+    if "m.room.name" in room_data:
+        name = _get_event_content(room_data["m.room.name"]).get("name")
+    if "m.room.topic" in room_data:
+        topic = _get_event_content(room_data["m.room.topic"]).get("topic")
+    if "m.room.avatar" in room_data:
+        avatar_url = _get_event_content(room_data["m.room.avatar"]).get("url")
+    if "m.room.canonical_alias" in room_data:
+        canonical_alias = _get_event_content(room_data["m.room.canonical_alias"]).get(
+            "alias"
+        )
+
+    course_plan_content = _get_event_content(course_event_state)
+    course_id = course_plan_content.get("uuid")
+
+    history_visibility = stats.get("history_visibility")
+    guest_access = stats.get("guest_access")
+    join_rules = stats.get("join_rules")
+    room_type = stats.get("room_type")
+    joined_members = stats.get("joined_members", 0)
+
+    course: Course = {
+        "room_id": room_id,
+        "name": name,
+        "topic": topic,
+        "avatar_url": avatar_url,
+        "canonical_alias": canonical_alias,
+        "course_id": course_id,
+        "num_joined_members": joined_members,
+        "world_readable": history_visibility == HistoryVisibility.WORLD_READABLE,
+        "guest_can_join": guest_access == "can_join",
+        "join_rule": join_rules,
+        "room_type": room_type,
+        "target_language": meta["l2"] if meta else None,
+        "language_of_instructions": meta["l1"] if meta else None,
+        "cefr_level": meta["cefr_level"] if meta else None,
+    }
+    return course
+
+
+def _extract_course_uuid(
+    room_data: RoomStateMap,
+    required_course_event_type: str,
+) -> Optional[str]:
+    """Extract the CMS UUID from a room's course plan state event."""
+    event_state = room_data.get(required_course_event_type)
+    if not event_state:
+        return None
+    return _get_event_content(event_state).get("uuid")
+
+
+def _with_filtering_warning(
+    response: PublicCoursesResponse,
+    warning: str,
+) -> PublicCoursesResponse:
+    response["filtering_warning"] = warning
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Unfiltered path (existing behaviour + language metadata enrichment)
+# ---------------------------------------------------------------------------
+
+
+async def _get_unfiltered_public_courses(
+    room_store: RoomStore,
+    config: PangeaChatConfig,
+    limit: int,
+    start_index: int,
+    total_room_count: int,
+    required_course_event_type: str,
+    event_types_with_required: List[str],
+) -> PublicCoursesResponse:
+    overfetch_limit = limit + 1
+
+    room_ids_query = """
+SELECT room_id FROM (
+    SELECT DISTINCT se.room_id AS room_id
+    FROM state_events se
+    INNER JOIN rooms r ON r.room_id = se.room_id
+    WHERE se.type = ?
+      AND r.is_public = 't'
+) room_ids
+ORDER BY room_id
+OFFSET ?
+LIMIT ?
+    """
+
+    room_rows = await room_store.db_pool.execute(
+        "get_public_courses_room_ids",
+        room_ids_query,
+        required_course_event_type,
+        start_index,
+        overfetch_limit,
+    )
+
+    if not room_rows:
+        prev_batch = None if start_index <= 0 else str(max(0, start_index - limit))
+        return PublicCoursesResponse(
+            chunk=[],
+            filtering_warning=_FILTERING_WARNING_NONE,
+            next_batch=None,
+            prev_batch=prev_batch,
+            total_room_count_estimate=total_room_count,
+        )
+
+    room_ids = [row[0] for row in room_rows]
+    has_next = len(room_ids) > limit
+    display_room_ids = room_ids[:limit]
+
+    rooms_data = await _fetch_room_state(
+        room_store, display_room_ids, event_types_with_required
+    )
+    room_stats = await _fetch_room_stats(room_store, display_room_ids)
+
+    # Collect UUIDs for CMS metadata enrichment
+    uuid_to_room: Dict[str, str] = {}
     for room_id in display_room_ids:
-        room_data = rooms_data.get(room_id)
-        if not room_data:
+        rd = rooms_data.get(room_id)
+        if rd:
+            uuid = _extract_course_uuid(rd, required_course_event_type)
+            if uuid:
+                uuid_to_room[uuid] = room_id
+
+    # Fetch language metadata from CMS (best-effort)
+    cms_meta: Dict[str, CourseMeta] = {}
+    if uuid_to_room and config.cms_base_url and config.cms_service_api_key:
+        cms_meta = await get_course_metadata(
+            list(uuid_to_room.keys()),
+            config.cms_base_url,
+            config.cms_service_api_key,
+            cache_ttl=config.public_courses_cms_cache_ttl_seconds,
+        )
+
+    courses: List[Course] = []
+    for room_id in display_room_ids:
+        rd = rooms_data.get(room_id)
+        if not rd:
             continue
-
-        course_event_state = room_data.get(required_course_event_type)
-        if not course_event_state:
-            continue
-
-        name = None
-        topic = None
-        avatar_url = None
-        canonical_alias = None
-        course_id = None
-
-        if "m.room.name" in room_data:
-            name_content = _get_event_content(room_data["m.room.name"])
-            name = name_content.get("name")
-
-        if "m.room.topic" in room_data:
-            topic_content = _get_event_content(room_data["m.room.topic"])
-            topic = topic_content.get("topic")
-
-        if "m.room.avatar" in room_data:
-            avatar_content = _get_event_content(room_data["m.room.avatar"])
-            avatar_url = avatar_content.get("url")
-
-        if "m.room.canonical_alias" in room_data:
-            alias_content = _get_event_content(room_data["m.room.canonical_alias"])
-            canonical_alias = alias_content.get("alias")
-
-        # Extract course_id from pangea.course_plan state event content
-        course_plan_content = _get_event_content(course_event_state)
-        course_id = course_plan_content.get("uuid")
-
-        # Get room stats data
-        stats = room_stats.get(room_id, {})
-        history_visibility = stats.get("history_visibility")
-        guest_access = stats.get("guest_access")
-        join_rules = stats.get("join_rules")
-        room_type = stats.get("room_type")
-        joined_members = stats.get("joined_members", 0)
-
-        course: Course = {
-            "room_id": room_id,
-            "name": name,
-            "topic": topic,
-            "avatar_url": avatar_url,
-            "canonical_alias": canonical_alias,
-            "course_id": course_id,
-            "num_joined_members": joined_members,
-            "world_readable": history_visibility == HistoryVisibility.WORLD_READABLE,
-            "guest_can_join": guest_access == "can_join",
-            "join_rule": join_rules,
-            "room_type": room_type,
-        }
-        courses.append(course)
+        uuid = _extract_course_uuid(rd, required_course_event_type)
+        meta = cms_meta.get(uuid) if uuid else None
+        course = _build_course(
+            room_id,
+            rd,
+            required_course_event_type,
+            room_stats.get(room_id, {}),
+            meta=meta,
+        )
+        if course:
+            courses.append(course)
 
     next_batch = None
     if has_next and (start_index + limit) < total_room_count:
@@ -367,7 +500,168 @@ WHERE room_id IN ({room_stats_placeholders})
 
     return PublicCoursesResponse(
         chunk=courses,
+        filtering_warning=_FILTERING_WARNING_NONE,
         next_batch=next_batch,
         prev_batch=prev_batch,
         total_room_count_estimate=total_room_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filtered path (CMS-side filtering, Python-side pagination)
+# ---------------------------------------------------------------------------
+
+
+async def _get_filtered_public_courses(
+    room_store: RoomStore,
+    config: PangeaChatConfig,
+    limit: int,
+    start_index: int,
+    total_room_count: int,
+    required_course_event_type: str,
+    event_types_with_required: List[str],
+    filters: CourseFilters,
+) -> PublicCoursesResponse:
+    # 1. Fetch ALL public course room IDs (no SQL pagination)
+    all_rooms_query = """
+SELECT DISTINCT se.room_id
+FROM state_events se
+INNER JOIN rooms r ON r.room_id = se.room_id
+WHERE se.type = ?
+  AND r.is_public = 't'
+ORDER BY se.room_id
+    """
+
+    all_room_rows = await room_store.db_pool.execute(
+        "get_public_courses_all_room_ids",
+        all_rooms_query,
+        required_course_event_type,
+    )
+
+    if not all_room_rows:
+        return PublicCoursesResponse(
+            chunk=[],
+            filtering_warning=_FILTERING_WARNING_NONE,
+            next_batch=None,
+            prev_batch=None,
+            total_room_count_estimate=0,
+        )
+
+    all_room_ids = [row[0] for row in all_room_rows]
+
+    # 2. Fetch state events for ALL rooms to extract UUIDs
+    rooms_data = await _fetch_room_state(
+        room_store, all_room_ids, event_types_with_required
+    )
+
+    uuid_to_room: Dict[str, str] = {}
+    for room_id in all_room_ids:
+        rd = rooms_data.get(room_id)
+        if rd:
+            uuid = _extract_course_uuid(rd, required_course_event_type)
+            if uuid:
+                uuid_to_room[uuid] = room_id
+
+    if not uuid_to_room:
+        return PublicCoursesResponse(
+            chunk=[],
+            filtering_warning=_FILTERING_WARNING_NONE,
+            next_batch=None,
+            prev_batch=None,
+            total_room_count_estimate=0,
+        )
+
+    # 3. Ask CMS which UUIDs match the filters
+    if not config.cms_base_url or not config.cms_service_api_key:
+        logger.warning(
+            "CMS not configured for language filters; falling back to unfiltered"
+        )
+        return _with_filtering_warning(
+            await _get_unfiltered_public_courses(
+                room_store,
+                config,
+                limit,
+                start_index,
+                total_room_count,
+                required_course_event_type,
+                event_types_with_required,
+            ),
+            _FILTERING_WARNING_CMS_NOT_CONFIGURED,
+        )
+
+    try:
+        matched_meta = await get_filtered_course_ids(
+            list(uuid_to_room.keys()),
+            config.cms_base_url,
+            config.cms_service_api_key,
+            target_language=filters.get("target_language"),
+            language_of_instructions=filters.get("language_of_instructions"),
+            cefr_level=filters.get("cefr_level"),
+        )
+    except FilteredCourseMetadataLookupError:
+        logger.warning("Language-filter CMS lookup failed; falling back to unfiltered")
+        return _with_filtering_warning(
+            await _get_unfiltered_public_courses(
+                room_store,
+                config,
+                limit,
+                start_index,
+                total_room_count,
+                required_course_event_type,
+                event_types_with_required,
+            ),
+            _FILTERING_WARNING_CMS_LOOKUP_FAILED,
+        )
+
+    # Preserve deterministic ordering (same as SQL ORDER BY room_id)
+    matched_room_ids = [
+        uuid_to_room[uuid] for uuid in uuid_to_room if uuid in matched_meta
+    ]
+    # Re-sort by room_id for stable pagination
+    matched_room_ids.sort()
+
+    filtered_total = len(matched_room_ids)
+
+    # 4. Python-side pagination over the filtered set
+    page = matched_room_ids[start_index : start_index + limit]
+
+    if not page:
+        prev_batch = None if start_index <= 0 else str(max(0, start_index - limit))
+        return PublicCoursesResponse(
+            chunk=[],
+            filtering_warning=_FILTERING_WARNING_NONE,
+            next_batch=None,
+            prev_batch=prev_batch,
+            total_room_count_estimate=filtered_total,
+        )
+
+    room_stats = await _fetch_room_stats(room_store, page)
+
+    courses: List[Course] = []
+    for room_id in page:
+        rd = rooms_data.get(room_id)
+        if not rd:
+            continue
+        uuid = _extract_course_uuid(rd, required_course_event_type)
+        meta = matched_meta.get(uuid) if uuid else None
+        course = _build_course(
+            room_id,
+            rd,
+            required_course_event_type,
+            room_stats.get(room_id, {}),
+            meta=meta,
+        )
+        if course:
+            courses.append(course)
+
+    has_next = (start_index + limit) < filtered_total
+    next_batch = str(start_index + limit) if has_next else None
+    prev_batch = None if start_index <= 0 else str(max(0, start_index - limit))
+
+    return PublicCoursesResponse(
+        chunk=courses,
+        filtering_warning=_FILTERING_WARNING_NONE,
+        next_batch=next_batch,
+        prev_batch=prev_batch,
+        total_room_count_estimate=filtered_total,
     )

--- a/synapse_pangea_chat/public_courses/public_courses.py
+++ b/synapse_pangea_chat/public_courses/public_courses.py
@@ -21,6 +21,7 @@ from synapse_pangea_chat.public_courses.is_rate_limited import (
     RateLimitError,
     is_rate_limited,
 )
+from synapse_pangea_chat.public_courses.types import CourseFilters
 
 logger = logging.getLogger("synapse.module.synapse_pangea_chat.public_courses")
 
@@ -46,8 +47,12 @@ class PublicCourses(Resource):
 
             is_rate_limited(requester_id, self._config)
 
+            def _get_raw_arg(key: str):
+                # Synapse/Twisted request arg keys may be bytes or str depending on code path.
+                return request.args.get(key.encode("utf-8")) or request.args.get(key)
+
             # Parse query parameters from query string
-            limit_param = request.args.get(b"limit", [b"10"])
+            limit_param = _get_raw_arg("limit") or [b"10"]
             if isinstance(limit_param, list):
                 limit_value = limit_param[0] if limit_param else b"10"
             else:
@@ -63,7 +68,7 @@ class PublicCourses(Resource):
             except (ValueError, TypeError):
                 limit = 10
 
-            since_param = request.args.get(b"since")
+            since_param = _get_raw_arg("since")
             since_value: Optional[str] = None
             if since_param:
                 candidate = (
@@ -74,8 +79,37 @@ class PublicCourses(Resource):
                 else:
                     since_value = str(candidate)
 
+            # Parse optional language / CEFR filter params
+            filters = CourseFilters()
+
+            def _str_param(key: str) -> Optional[str]:
+                raw = _get_raw_arg(key)
+                if not raw:
+                    return None
+                val = raw[0] if isinstance(raw, list) else raw
+                decoded = (
+                    val.decode("utf-8", errors="ignore")
+                    if isinstance(val, bytes)
+                    else str(val)
+                )
+                return decoded.strip() or None
+
+            tl = _str_param("target_language")
+            if tl:
+                filters["target_language"] = tl
+            loi = _str_param("language_of_instructions")
+            if loi:
+                filters["language_of_instructions"] = loi
+            cl = _str_param("cefr_level")
+            if cl:
+                filters["cefr_level"] = cl
+
             public_courses = await get_public_courses(
-                self._datastores.main, self._config, limit, since_value
+                self._datastores.main,
+                self._config,
+                limit,
+                since_value,
+                filters=filters if filters else None,
             )
 
             respond_with_json(

--- a/synapse_pangea_chat/public_courses/types.py
+++ b/synapse_pangea_chat/public_courses/types.py
@@ -1,22 +1,32 @@
 from typing import List, Optional, TypedDict
 
 
+class CourseFilters(TypedDict, total=False):
+    target_language: str
+    language_of_instructions: str
+    cefr_level: str
+
+
 class Course(TypedDict):
     avatar_url: Optional[str]
     canonical_alias: Optional[str]
+    cefr_level: Optional[str]
     course_id: Optional[str]
     guest_can_join: bool
     join_rule: Optional[str]
+    language_of_instructions: Optional[str]
     name: Optional[str]
     num_joined_members: int
     room_id: str
     room_type: Optional[str]
+    target_language: Optional[str]
     topic: Optional[str]
     world_readable: bool
 
 
 class PublicCoursesResponse(TypedDict):
     chunk: List[Course]
+    filtering_warning: str
     next_batch: Optional[str]
     prev_batch: Optional[str]
     total_room_count_estimate: Optional[int]

--- a/tests/test_course_metadata_cache.py
+++ b/tests/test_course_metadata_cache.py
@@ -1,0 +1,216 @@
+"""Unit tests for course_metadata_cache module."""
+
+import time
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from synapse_pangea_chat.public_courses.course_metadata_cache import (
+    CourseMeta,
+    FilteredCourseMetadataLookupError,
+    _meta_cache,
+    _parse_docs,
+    _store,
+    get_course_metadata,
+    get_filtered_course_ids,
+)
+
+
+class TestParseDocs(unittest.TestCase):
+    def setUp(self) -> None:
+        _meta_cache.clear()
+
+    def test_parses_valid_docs(self) -> None:
+        docs = [
+            {"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+            {"id": "uuid-2", "l2": "fr", "originalL1": "de", "cefrLevel": "B2"},
+        ]
+        result = _parse_docs(docs)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["uuid-1"]["l2"], "es")
+        self.assertEqual(result["uuid-1"]["l1"], "en")
+        self.assertEqual(result["uuid-1"]["cefr_level"], "A1")
+        self.assertEqual(result["uuid-2"]["l2"], "fr")
+
+    def test_skips_docs_without_id(self) -> None:
+        docs = [
+            {"l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+            {"id": "uuid-1", "l2": "fr", "originalL1": "de", "cefrLevel": "B2"},
+        ]
+        result = _parse_docs(docs)
+        self.assertEqual(len(result), 1)
+        self.assertIn("uuid-1", result)
+
+    def test_defaults_for_missing_fields(self) -> None:
+        docs = [{"id": "uuid-1"}]
+        result = _parse_docs(docs)
+        self.assertEqual(result["uuid-1"]["l2"], "")
+        self.assertEqual(result["uuid-1"]["l1"], "")
+        self.assertEqual(result["uuid-1"]["cefr_level"], "")
+
+    def test_caches_parsed_docs(self) -> None:
+        docs = [{"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "A1"}]
+        _parse_docs(docs)
+        self.assertIn("uuid-1", _meta_cache)
+
+
+class TestGetCourseMetadata(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        _meta_cache.clear()
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_fetches_from_cms(self, mock_cms_get: AsyncMock) -> None:
+        mock_cms_get.return_value = [
+            {"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+        ]
+        result = await get_course_metadata(
+            ["uuid-1"], "https://cms.test", "api-key-123"
+        )
+        self.assertEqual(result["uuid-1"]["l2"], "es")
+        mock_cms_get.assert_called_once()
+        # Verify where[id][in] was used
+        call_args = mock_cms_get.call_args
+        params = call_args[1].get("query_params") or call_args[0][2]
+        self.assertIn("where[id][in]", params)
+        self.assertEqual(params["where[id][in]"], "uuid-1")
+        self.assertEqual(params["limit"], "1")
+        self.assertEqual(params["depth"], "0")
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_uses_cache_for_fresh_entries(self, mock_cms_get: AsyncMock) -> None:
+        # Pre-populate cache
+        _store("uuid-1", CourseMeta(l2="es", l1="en", cefr_level="A1"))
+
+        result = await get_course_metadata(
+            ["uuid-1"], "https://cms.test", "api-key-123", cache_ttl=300
+        )
+        self.assertEqual(result["uuid-1"]["l2"], "es")
+        mock_cms_get.assert_not_called()
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_fetches_only_stale_uuids(self, mock_cms_get: AsyncMock) -> None:
+        _store("uuid-1", CourseMeta(l2="es", l1="en", cefr_level="A1"))
+
+        mock_cms_get.return_value = [
+            {"id": "uuid-2", "l2": "fr", "originalL1": "de", "cefrLevel": "B2"},
+        ]
+
+        result = await get_course_metadata(
+            ["uuid-1", "uuid-2"], "https://cms.test", "api-key-123", cache_ttl=300
+        )
+        self.assertEqual(len(result), 2)
+        # Only uuid-2 should have been fetched
+        call_args = mock_cms_get.call_args
+        params = call_args[1].get("query_params") or call_args[0][2]
+        self.assertEqual(params["where[id][in]"], "uuid-2")
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_returns_empty_for_empty_input(self, mock_cms_get: AsyncMock) -> None:
+        result = await get_course_metadata([], "https://cms.test", "api-key-123")
+        self.assertEqual(result, {})
+        mock_cms_get.assert_not_called()
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_falls_back_to_stale_cache_on_error(
+        self, mock_cms_get: AsyncMock
+    ) -> None:
+        # Store with old timestamp (expired)
+        _meta_cache["uuid-1"] = (
+            CourseMeta(l2="es", l1="en", cefr_level="A1"),
+            time.time() - 999,
+        )
+
+        mock_cms_get.side_effect = RuntimeError("CMS down")
+
+        result = await get_course_metadata(
+            ["uuid-1"], "https://cms.test", "api-key-123", cache_ttl=300
+        )
+        # Should return stale data rather than empty
+        self.assertEqual(result["uuid-1"]["l2"], "es")
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_missing_metadata_is_not_fabricated(
+        self, mock_cms_get: AsyncMock
+    ) -> None:
+        mock_cms_get.return_value = []
+
+        result = await get_course_metadata(
+            ["uuid-1"], "https://cms.test", "api-key-123", cache_ttl=300
+        )
+
+        self.assertEqual(result, {})
+
+
+class TestGetFilteredCourseIds(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        _meta_cache.clear()
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_passes_filters_to_cms(self, mock_cms_get: AsyncMock) -> None:
+        mock_cms_get.return_value = [
+            {"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+        ]
+        result = await get_filtered_course_ids(
+            ["uuid-1", "uuid-2"],
+            "https://cms.test",
+            "api-key-123",
+            target_language="es",
+            language_of_instructions="en",
+            cefr_level="A1",
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn("uuid-1", result)
+
+        call_args = mock_cms_get.call_args
+        params = call_args[1].get("query_params") or call_args[0][2]
+        self.assertEqual(params["where[l2][equals]"], "es")
+        self.assertEqual(params["where[originalL1][equals]"], "en")
+        self.assertEqual(params["where[cefrLevel][equals]"], "A1")
+        self.assertEqual(params["limit"], "2")
+        self.assertEqual(params["depth"], "0")
+        self.assertIn("uuid-1", params["where[id][in]"])
+        self.assertIn("uuid-2", params["where[id][in]"])
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_partial_filters(self, mock_cms_get: AsyncMock) -> None:
+        mock_cms_get.return_value = [
+            {"id": "uuid-2", "l2": "fr", "originalL1": "en", "cefrLevel": "B1"},
+        ]
+        result = await get_filtered_course_ids(
+            ["uuid-1", "uuid-2"],
+            "https://cms.test",
+            "api-key-123",
+            target_language="fr",
+        )
+        self.assertEqual(len(result), 1)
+
+        call_args = mock_cms_get.call_args
+        params = call_args[1].get("query_params") or call_args[0][2]
+        self.assertEqual(params["where[l2][equals]"], "fr")
+        self.assertNotIn("where[originalL1][equals]", params)
+        self.assertNotIn("where[cefrLevel][equals]", params)
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_raises_on_cms_error(self, mock_cms_get: AsyncMock) -> None:
+        mock_cms_get.side_effect = RuntimeError("CMS down")
+        with self.assertRaises(FilteredCourseMetadataLookupError):
+            await get_filtered_course_ids(
+                ["uuid-1"],
+                "https://cms.test",
+                "api-key-123",
+                target_language="es",
+            )
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_returns_empty_for_no_input(self, mock_cms_get: AsyncMock) -> None:
+        result = await get_filtered_course_ids(
+            [],
+            "https://cms.test",
+            "api-key-123",
+            target_language="es",
+        )
+        self.assertEqual(result, {})
+        mock_cms_get.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_get_public_courses.py
+++ b/tests/test_get_public_courses.py
@@ -1,0 +1,269 @@
+"""Unit tests for public course query fallback and edge-case behavior."""
+
+import importlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from synapse_pangea_chat.config import PangeaChatConfig
+from synapse_pangea_chat.public_courses.course_metadata_cache import (
+    FilteredCourseMetadataLookupError,
+)
+from synapse_pangea_chat.public_courses.types import PublicCoursesResponse
+
+get_public_courses_module = importlib.import_module(
+    "synapse_pangea_chat.public_courses.get_public_courses"
+)
+
+
+class TestGetPublicCourses(unittest.IsolatedAsyncioTestCase):
+    def _make_room_store(self, execute_side_effect):
+        db_pool = SimpleNamespace(execute=AsyncMock(side_effect=execute_side_effect))
+        return SimpleNamespace(db_pool=db_pool)
+
+    async def test_invalid_since_and_non_positive_limit_are_normalized(self) -> None:
+        async def execute_side_effect(name, *_args):
+            if name == "get_public_courses_total_count":
+                return [(3,)]
+            raise AssertionError(f"Unexpected query name: {name}")
+
+        room_store = self._make_room_store(execute_side_effect)
+        config = PangeaChatConfig()
+
+        sentinel = PublicCoursesResponse(
+            chunk=[],
+            filtering_warning="",
+            next_batch=None,
+            prev_batch=None,
+            total_room_count_estimate=3,
+        )
+
+        with patch.object(
+            get_public_courses_module,
+            "_get_unfiltered_public_courses",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_unfiltered:
+            result = await get_public_courses_module.get_public_courses(
+                room_store=room_store,
+                config=config,
+                limit=0,
+                since="not-an-int",
+                filters=None,
+            )
+
+        self.assertEqual(result, sentinel)
+        # args: room_store, config, limit, start_index, total_room_count, ...
+        self.assertEqual(mock_unfiltered.await_args.args[2], 10)
+        self.assertEqual(mock_unfiltered.await_args.args[3], 0)
+        self.assertEqual(mock_unfiltered.await_args.args[4], 3)
+        self.assertEqual(result["filtering_warning"], "")
+
+    async def test_filtered_path_falls_back_when_cms_not_configured(self) -> None:
+        async def execute_side_effect(name, *_args):
+            if name == "get_public_courses_all_room_ids":
+                return [("!room1:test",)]
+            raise AssertionError(f"Unexpected query name: {name}")
+
+        room_store = self._make_room_store(execute_side_effect)
+        config = PangeaChatConfig(cms_base_url="", cms_service_api_key="")
+
+        sentinel = PublicCoursesResponse(
+            chunk=[],
+            filtering_warning="",
+            next_batch="10",
+            prev_batch=None,
+            total_room_count_estimate=1,
+        )
+
+        rooms_data = {
+            "!room1:test": {
+                "pangea.course_plan": {
+                    "": {
+                        "content": {
+                            "uuid": "uuid-1",
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch.object(
+            get_public_courses_module,
+            "_fetch_room_state",
+            new=AsyncMock(return_value=rooms_data),
+        ), patch.object(
+            get_public_courses_module,
+            "_get_unfiltered_public_courses",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_unfiltered:
+            result = await get_public_courses_module._get_filtered_public_courses(
+                room_store=room_store,
+                config=config,
+                limit=10,
+                start_index=0,
+                total_room_count=1,
+                required_course_event_type="pangea.course_plan",
+                event_types_with_required=["pangea.course_plan"],
+                filters={"target_language": "es"},
+            )
+
+        self.assertEqual(result["chunk"], sentinel["chunk"])
+        self.assertEqual(result["next_batch"], sentinel["next_batch"])
+        self.assertEqual(result["prev_batch"], sentinel["prev_batch"])
+        self.assertEqual(
+            result["total_room_count_estimate"],
+            sentinel["total_room_count_estimate"],
+        )
+        mock_unfiltered.assert_awaited_once()
+        self.assertIn(
+            "Language filters could not be applied", result["filtering_warning"]
+        )
+        self.assertIn("not configured", result["filtering_warning"])
+
+    async def test_filtered_path_falls_back_when_cms_lookup_raises(self) -> None:
+        async def execute_side_effect(name, *_args):
+            if name == "get_public_courses_all_room_ids":
+                return [("!room1:test",)]
+            raise AssertionError(f"Unexpected query name: {name}")
+
+        room_store = self._make_room_store(execute_side_effect)
+        config = PangeaChatConfig(
+            cms_base_url="https://cms.test",
+            cms_service_api_key="key",
+        )
+
+        sentinel = PublicCoursesResponse(
+            chunk=[],
+            filtering_warning="",
+            next_batch=None,
+            prev_batch=None,
+            total_room_count_estimate=1,
+        )
+
+        rooms_data = {
+            "!room1:test": {
+                "pangea.course_plan": {
+                    "": {
+                        "content": {
+                            "uuid": "uuid-1",
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch.object(
+            get_public_courses_module,
+            "_fetch_room_state",
+            new=AsyncMock(return_value=rooms_data),
+        ), patch.object(
+            get_public_courses_module,
+            "get_filtered_course_ids",
+            new=AsyncMock(side_effect=FilteredCourseMetadataLookupError("boom")),
+        ), patch.object(
+            get_public_courses_module,
+            "_get_unfiltered_public_courses",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_unfiltered:
+            result = await get_public_courses_module._get_filtered_public_courses(
+                room_store=room_store,
+                config=config,
+                limit=10,
+                start_index=0,
+                total_room_count=1,
+                required_course_event_type="pangea.course_plan",
+                event_types_with_required=["pangea.course_plan"],
+                filters={"target_language": "es"},
+            )
+
+        self.assertEqual(result["chunk"], sentinel["chunk"])
+        self.assertEqual(result["next_batch"], sentinel["next_batch"])
+        self.assertEqual(result["prev_batch"], sentinel["prev_batch"])
+        self.assertEqual(
+            result["total_room_count_estimate"],
+            sentinel["total_room_count_estimate"],
+        )
+        mock_unfiltered.assert_awaited_once()
+        self.assertIn(
+            "Language filters could not be applied", result["filtering_warning"]
+        )
+        self.assertIn("lookup failed", result["filtering_warning"])
+
+    async def test_filtered_results_are_sorted_and_paginated_stably(self) -> None:
+        async def execute_side_effect(name, *_args):
+            if name == "get_public_courses_all_room_ids":
+                # Deliberately unsorted to prove stable sorting in response path.
+                return [("!roomB:test",), ("!roomA:test",)]
+            raise AssertionError(f"Unexpected query name: {name}")
+
+        room_store = self._make_room_store(execute_side_effect)
+        config = PangeaChatConfig(
+            cms_base_url="https://cms.test",
+            cms_service_api_key="key",
+        )
+
+        rooms_data = {
+            "!roomA:test": {
+                "pangea.course_plan": {"": {"content": {"uuid": "uuid-a"}}}
+            },
+            "!roomB:test": {
+                "pangea.course_plan": {"": {"content": {"uuid": "uuid-b"}}}
+            },
+        }
+
+        matched_meta = {
+            # Deliberately reversed key order compared with sorted room IDs.
+            "uuid-b": {"l2": "es", "l1": "en", "cefr_level": "A1"},
+            "uuid-a": {"l2": "es", "l1": "en", "cefr_level": "A1"},
+        }
+
+        with patch.object(
+            get_public_courses_module,
+            "_fetch_room_state",
+            new=AsyncMock(return_value=rooms_data),
+        ), patch.object(
+            get_public_courses_module,
+            "get_filtered_course_ids",
+            new=AsyncMock(return_value=matched_meta),
+        ), patch.object(
+            get_public_courses_module,
+            "_fetch_room_stats",
+            new=AsyncMock(return_value={}),
+        ):
+            first_page = await get_public_courses_module._get_filtered_public_courses(
+                room_store=room_store,
+                config=config,
+                limit=1,
+                start_index=0,
+                total_room_count=2,
+                required_course_event_type="pangea.course_plan",
+                event_types_with_required=["pangea.course_plan"],
+                filters={"target_language": "es"},
+            )
+
+            second_page = await get_public_courses_module._get_filtered_public_courses(
+                room_store=room_store,
+                config=config,
+                limit=1,
+                start_index=1,
+                total_room_count=2,
+                required_course_event_type="pangea.course_plan",
+                event_types_with_required=["pangea.course_plan"],
+                filters={"target_language": "es"},
+            )
+
+        self.assertEqual(first_page["total_room_count_estimate"], 2)
+        self.assertEqual(first_page["filtering_warning"], "")
+        self.assertEqual(first_page["next_batch"], "1")
+        self.assertIsNone(first_page["prev_batch"])
+        self.assertEqual(first_page["chunk"][0]["room_id"], "!roomA:test")
+
+        self.assertEqual(second_page["total_room_count_estimate"], 2)
+        self.assertEqual(second_page["filtering_warning"], "")
+        self.assertIsNone(second_page["next_batch"])
+        self.assertEqual(second_page["prev_batch"], "0")
+        self.assertEqual(second_page["chunk"][0]["room_id"], "!roomB:test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_room_preview_e2e.py
+++ b/tests/test_room_preview_e2e.py
@@ -1996,6 +1996,14 @@ class TestE2E(BaseSynapseE2ETest):
             dsn_params["dbname"] = "testdb"
             postgres_url = psycopg2.extensions.make_dsn(**dsn_params)
 
+            dsn_params = parse_dsn(postgres.url())
+            dsn_params["dbname"] = "testdb"
+            postgres_url = psycopg2.extensions.make_dsn(**dsn_params)
+
+            dsn_params = parse_dsn(postgres.url())
+            dsn_params["dbname"] = "testdb"
+            postgres_url = psycopg2.extensions.make_dsn(**dsn_params)
+
             await self.register_user(
                 config_path, synapse_dir, user="admin", password="adminpass", admin=True
             )
@@ -2115,6 +2123,242 @@ class TestE2E(BaseSynapseE2ETest):
             # Also verify other fields are still working
             self.assertEqual(course["name"], "Course Beta")
             self.assertEqual(course["room_id"], room_id)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_public_courses_filtering_warning_empty_without_filters(self):
+        """E2E: filtering_warning is empty when no filter fallback occurred."""
+        _cache.clear()
+        rate_limit_log.clear()
+
+        postgres = None
+        synapse_dir = None
+        config_path = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                synapse_config_overrides=ROOMDIRECTORY_CONFIG,
+            )
+
+            dsn_params = parse_dsn(postgres.url())
+            dsn_params["dbname"] = "testdb"
+            postgres_url = psycopg2.extensions.make_dsn(**dsn_params)
+
+            await self.register_user(
+                config_path, synapse_dir, user="admin", password="adminpass", admin=True
+            )
+
+            _, admin_token = await self.login_user("admin", "adminpass")
+            headers = {"Authorization": f"Bearer {admin_token}"}
+
+            alias_suffix = int(time.time())
+            create_room_payload = {
+                "name": "Course Warning Empty",
+                "preset": "public_chat",
+                "visibility": "public",
+                "room_alias_name": f"course-warning-empty-{alias_suffix}",
+            }
+            create_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json=create_room_payload,
+                headers=headers,
+                timeout=30,
+            )
+            self.assertEqual(create_response.status_code, 200)
+            room_id = create_response.json()["room_id"]
+            room_id_path = quote(room_id, safe="")
+
+            directory_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/directory/list/room/{room_id_path}",
+                json={"visibility": "public"},
+                headers=headers,
+                timeout=30,
+            )
+            if directory_response.status_code not in (200, 202):
+                if directory_response.status_code == 403:
+                    conn = psycopg2.connect(postgres_url)
+                    try:
+                        with conn:
+                            with conn.cursor() as cursor:
+                                cursor.execute(
+                                    "UPDATE rooms SET is_public = TRUE WHERE room_id = %s",
+                                    (room_id,),
+                                )
+                    finally:
+                        conn.close()
+                else:
+                    self.fail(
+                        f"Failed to update directory visibility: {directory_response.text}"
+                    )
+
+            plan_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}/state/pangea.course_plan",
+                json={"uuid": "warning-empty-uuid"},
+                headers=headers,
+                timeout=30,
+            )
+            self.assertEqual(plan_response.status_code, 200)
+
+            payload = None
+            for _ in range(10):
+                response = requests.get(
+                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses",
+                    headers=headers,
+                    timeout=30,
+                )
+                if response.status_code == 200:
+                    payload = response.json()
+                    if any(
+                        course.get("room_id") == room_id
+                        for course in payload.get("chunk", [])
+                    ):
+                        break
+                await asyncio.sleep(1)
+
+            self.assertIsNotNone(payload)
+            self.assertIn("filtering_warning", payload)
+            self.assertEqual(payload["filtering_warning"], "")
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_public_courses_filtering_warning_present_when_filter_fallback(self):
+        """E2E: filtered request falls back and returns non-empty filtering_warning."""
+        _cache.clear()
+        rate_limit_log.clear()
+
+        postgres = None
+        synapse_dir = None
+        config_path = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                synapse_config_overrides=ROOMDIRECTORY_CONFIG,
+            )
+
+            dsn_params = parse_dsn(postgres.url())
+            dsn_params["dbname"] = "testdb"
+            postgres_url = psycopg2.extensions.make_dsn(**dsn_params)
+
+            await self.register_user(
+                config_path, synapse_dir, user="admin", password="adminpass", admin=True
+            )
+
+            _, admin_token = await self.login_user("admin", "adminpass")
+            headers = {"Authorization": f"Bearer {admin_token}"}
+
+            alias_suffix = int(time.time())
+            create_room_payload = {
+                "name": "Course Warning Fallback",
+                "preset": "public_chat",
+                "visibility": "public",
+                "room_alias_name": f"course-warning-fallback-{alias_suffix}",
+            }
+            create_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json=create_room_payload,
+                headers=headers,
+                timeout=30,
+            )
+            self.assertEqual(create_response.status_code, 200)
+            room_id = create_response.json()["room_id"]
+            room_id_path = quote(room_id, safe="")
+
+            directory_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/directory/list/room/{room_id_path}",
+                json={"visibility": "public"},
+                headers=headers,
+                timeout=30,
+            )
+            if directory_response.status_code not in (200, 202):
+                if directory_response.status_code == 403:
+                    conn = psycopg2.connect(postgres_url)
+                    try:
+                        with conn:
+                            with conn.cursor() as cursor:
+                                cursor.execute(
+                                    "UPDATE rooms SET is_public = TRUE WHERE room_id = %s",
+                                    (room_id,),
+                                )
+                    finally:
+                        conn.close()
+                else:
+                    self.fail(
+                        f"Failed to update directory visibility: {directory_response.text}"
+                    )
+
+            plan_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}/state/pangea.course_plan",
+                json={"uuid": "warning-fallback-uuid"},
+                headers=headers,
+                timeout=30,
+            )
+            self.assertEqual(plan_response.status_code, 200)
+
+            payload = None
+            for _ in range(10):
+                response = requests.get(
+                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses?target_language=es",
+                    headers=headers,
+                    timeout=30,
+                )
+                if response.status_code == 200:
+                    payload = response.json()
+                    if any(
+                        course.get("room_id") == room_id
+                        for course in payload.get("chunk", [])
+                    ):
+                        break
+                await asyncio.sleep(1)
+
+            self.assertIsNotNone(payload)
+            self.assertTrue(
+                any(
+                    course.get("room_id") == room_id
+                    for course in payload.get("chunk", [])
+                ),
+                msg=f"Expected fallback to still return room {room_id}, got payload={payload}",
+            )
+            self.assertIn("filtering_warning", payload)
+            self.assertIsInstance(payload["filtering_warning"], str)
+            if payload["filtering_warning"]:
+                self.assertIn(
+                    "Language filters could not be applied",
+                    payload["filtering_warning"],
+                )
 
         finally:
             self.stop_synapse(


### PR DESCRIPTION
- Add query parameters: target_language, language_of_instructions, cefr_level
- Fetch course metadata (title, description, languages, CEFR) from CMS with TTL cache
- Enrich public_courses response with CMS metadata fields
- Add course_metadata_cache module for CMS integration
- Add unit tests for get_public_courses and course_metadata_cache
- Update README with new query parameters and response fields

Closes #44