### PR TITLE
fix(gdpr): include cms process-token-feedback-logs in export and delete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+	"python-envs.pythonProjects": [
+		{
+			"path": ".",
+			"envManager": "ms-python.python:venv",
+			"packageManager": "ms-python.python:pip"
+		}
+	]
+}

--- a/synapse_pangea_chat/delete_user/delete_user.py
+++ b/synapse_pangea_chat/delete_user/delete_user.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Dict
+from urllib.parse import quote
 
 from synapse.api.errors import (
     AuthError,
@@ -15,10 +17,12 @@ from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
 from synapse.module_api import ModuleApi
 from synapse.types import create_requester
+
 try:
     from synapse.util.duration import Duration
 except ImportError:
     import synapse as _synapse
+
     raise ImportError(
         f"synapse_pangea_chat.delete_user requires Synapse >= 1.148.0 "
         f"(synapse.util.duration is not available in Synapse {_synapse.__version__}). "
@@ -203,6 +207,9 @@ class DeleteUser(Resource):
                     "user_id": target_user_id,
                     "deleted_external_ids": delete_result["deleted_external_ids"],
                     "deleted_threepids": delete_result["deleted_threepids"],
+                    "deleted_cms_feedback_logs": delete_result[
+                        "deleted_cms_feedback_logs"
+                    ],
                 },
                 send_cors=True,
             )
@@ -253,6 +260,8 @@ class DeleteUser(Resource):
                 threepid.address,
             )
 
+        deleted_cms_feedback_logs = await self._cms_delete_token_feedback_logs(user_id)
+
         await self._deactivate_account_handler.deactivate_account(
             user_id=user_id,
             erase_data=True,
@@ -263,7 +272,56 @@ class DeleteUser(Resource):
         return {
             "deleted_external_ids": len(external_ids),
             "deleted_threepids": len(threepids),
+            "deleted_cms_feedback_logs": deleted_cms_feedback_logs,
         }
+
+    async def _cms_delete_token_feedback_logs(self, user_id: str) -> int:
+        """Bulk-delete all feedback logs for *user_id* from CMS.
+
+        Returns number of deleted docs, or 0 on failure (non-blocking).
+        """
+        cms_base_url = self._config.cms_base_url
+        cms_api_key = self._config.cms_service_api_key
+        if not cms_base_url or not cms_api_key:
+            return 0
+
+        try:
+            from twisted.internet import reactor
+            from twisted.web.client import Agent, readBody
+            from twisted.web.http_headers import Headers
+
+            agent = Agent(reactor)
+            encoded_uid = quote(user_id, safe="")
+            url = (
+                f"{cms_base_url}/api/process-token-feedback-logs"
+                f"?where[req.user_id][equals]={encoded_uid}"
+            ).encode("utf-8")
+
+            response = await agent.request(
+                b"DELETE",
+                url,
+                Headers(
+                    {
+                        b"Authorization": [
+                            f"users API-Key {cms_api_key}".encode("utf-8")
+                        ],
+                    }
+                ),
+            )
+            resp_body = await readBody(response)
+            if response.code >= 400:
+                logger.warning(
+                    "CMS feedback-logs delete failed (%s): %s",
+                    response.code,
+                    resp_body.decode("utf-8", errors="replace"),
+                )
+                return 0
+
+            data = json.loads(resp_body)
+            return len(data.get("docs", []))
+        except Exception as e:
+            logger.warning("Failed to delete CMS feedback logs for %s: %s", user_id, e)
+            return 0
 
     async def _ensure_schedule_table(self) -> None:
         if self._schedule_table_ready:

--- a/synapse_pangea_chat/export_user_data/export_user_data.py
+++ b/synapse_pangea_chat/export_user_data/export_user_data.py
@@ -6,6 +6,7 @@ import logging
 import os
 import zipfile
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence
+from urllib.parse import quote
 
 from synapse.api.errors import (
     AuthError,
@@ -332,6 +333,11 @@ class ExportUserData(Resource):
         await self._admin_handler.export_user_data(user_id, writer)
         export_data = writer.finished()
 
+        # Step 1b: Fetch CMS feedback logs and attach to export data
+        export_data[
+            "cms_process_token_feedback_logs"
+        ] = await self._cms_fetch_token_feedback_logs(user_id)
+
         # Step 2: Build ZIP
         zip_bytes = await self._build_export_zip(user_id, export_data)
 
@@ -443,6 +449,67 @@ class ExportUserData(Resource):
                     logger.warning("Failed to include media %s: %s", media_id, e)
 
         return buf.getvalue()
+
+    async def _cms_fetch_token_feedback_logs(
+        self, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Fetch all process-token-feedback-logs for *user_id* from CMS.
+
+        Paginates through all pages. Returns [] on any failure (non-blocking).
+        """
+        cms_base_url = self._config.cms_base_url
+        cms_api_key = self._config.cms_service_api_key
+        if not cms_base_url or not cms_api_key:
+            return []
+
+        try:
+            from twisted.internet import reactor
+            from twisted.web.client import Agent, readBody
+            from twisted.web.http_headers import Headers
+
+            agent = Agent(reactor)
+            all_docs: List[Dict[str, Any]] = []
+            page = 1
+
+            while True:
+                encoded_uid = quote(user_id, safe="")
+                url = (
+                    f"{cms_base_url}/api/process-token-feedback-logs"
+                    f"?where[req.user_id][equals]={encoded_uid}"
+                    f"&limit=100&page={page}"
+                ).encode("utf-8")
+
+                response = await agent.request(
+                    b"GET",
+                    url,
+                    Headers(
+                        {
+                            b"Authorization": [
+                                f"users API-Key {cms_api_key}".encode("utf-8")
+                            ],
+                        }
+                    ),
+                )
+                resp_body = await readBody(response)
+                if response.code >= 400:
+                    logger.warning(
+                        "CMS feedback-logs fetch failed (%s): %s",
+                        response.code,
+                        resp_body.decode("utf-8", errors="replace"),
+                    )
+                    return all_docs
+
+                data = json.loads(resp_body)
+                all_docs.extend(data.get("docs", []))
+
+                if not data.get("hasNextPage"):
+                    break
+                page = data.get("nextPage", page + 1)
+
+            return all_docs
+        except Exception as e:
+            logger.warning("Failed to fetch CMS feedback logs for %s: %s", user_id, e)
+            return []
 
     # ---- CMS API helpers ----
 

--- a/tests/mock_cms_server.py
+++ b/tests/mock_cms_server.py
@@ -1,0 +1,158 @@
+"""Mock CMS HTTP server for E2E tests.
+
+Implements Payload-compatible routes for process-token-feedback-logs
+and user-exports, backed by in-memory storage.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
+
+
+class _MockCmsHandler(BaseHTTPRequestHandler):
+    """Request handler backed by the server's in-memory state."""
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass  # suppress request logging in test output
+
+    def _send_json(self, code: int, body: Any) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    # --- routing ---
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/process-token-feedback-logs":
+            self._handle_get_feedback_logs(parsed.query)
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def do_DELETE(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/process-token-feedback-logs":
+            self._handle_delete_feedback_logs(parsed.query)
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/user-exports":
+            self._handle_create_export()
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def do_PATCH(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/api/user-exports/"):
+            self._handle_update_export(parsed.path)
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    # --- feedback-logs handlers ---
+
+    def _handle_get_feedback_logs(self, query_string: str) -> None:
+        qs = parse_qs(query_string)
+        user_id = qs.get("where[req.user_id][equals]", [None])[0]
+        page = int(qs.get("page", ["1"])[0])
+        limit = int(qs.get("limit", ["100"])[0])
+
+        state: "_MockCmsState" = self.server._state  # type: ignore[attr-defined]
+        all_logs = state.get_logs(user_id) if user_id else []
+
+        start = (page - 1) * limit
+        end = start + limit
+        page_docs = all_logs[start:end]
+        has_next = end < len(all_logs)
+
+        self._send_json(
+            200,
+            {
+                "docs": page_docs,
+                "totalDocs": len(all_logs),
+                "hasNextPage": has_next,
+                "nextPage": page + 1 if has_next else None,
+                "page": page,
+                "limit": limit,
+            },
+        )
+
+    def _handle_delete_feedback_logs(self, query_string: str) -> None:
+        qs = parse_qs(query_string)
+        user_id = qs.get("where[req.user_id][equals]", [None])[0]
+
+        state: "_MockCmsState" = self.server._state  # type: ignore[attr-defined]
+        deleted = state.delete_logs(user_id) if user_id else []
+
+        self._send_json(200, {"docs": deleted})
+
+    # --- user-exports handlers ---
+
+    def _handle_create_export(self) -> None:
+        self._send_json(200, {"doc": {"id": "mock-export-id"}})
+
+    def _handle_update_export(self, path: str) -> None:
+        self._send_json(200, {"doc": {"id": path.split("/")[-1]}})
+
+
+class _MockCmsState:
+    """Thread-safe in-memory store for feedback logs."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._logs: Dict[str, List[Dict[str, Any]]] = {}
+
+    def seed(self, user_id: str, logs: List[Dict[str, Any]]) -> None:
+        with self._lock:
+            self._logs.setdefault(user_id, []).extend(logs)
+
+    def get_logs(self, user_id: Optional[str]) -> List[Dict[str, Any]]:
+        with self._lock:
+            if user_id is None:
+                return []
+            return list(self._logs.get(user_id, []))
+
+    def delete_logs(self, user_id: Optional[str]) -> List[Dict[str, Any]]:
+        with self._lock:
+            if user_id is None:
+                return []
+            return self._logs.pop(user_id, [])
+
+    def get_remaining_logs(self, user_id: str) -> List[Dict[str, Any]]:
+        return self.get_logs(user_id)
+
+
+class MockCmsServer:
+    """Start/stop a mock CMS HTTP server on a random port."""
+
+    def __init__(self) -> None:
+        self._state = _MockCmsState()
+        self._server: Optional[HTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def seed_feedback_logs(self, user_id: str, logs: List[Dict[str, Any]]) -> None:
+        self._state.seed(user_id, logs)
+
+    def get_remaining_logs(self, user_id: str) -> List[Dict[str, Any]]:
+        return self._state.get_remaining_logs(user_id)
+
+    def start(self) -> str:
+        """Start the server and return its base URL (e.g. http://127.0.0.1:PORT)."""
+        self._server = HTTPServer(("127.0.0.1", 0), _MockCmsHandler)
+        self._server._state = self._state  # type: ignore[attr-defined]
+        port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://127.0.0.1:{port}"
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+        if self._thread:
+            self._thread.join(timeout=5)

--- a/tests/test_delete_user_e2e.py
+++ b/tests/test_delete_user_e2e.py
@@ -5,6 +5,7 @@ import yaml
 from psycopg2 import connect
 
 from .base_e2e import BaseSynapseE2ETest
+from .mock_cms_server import MockCmsServer
 
 
 class TestDeleteUserE2E(BaseSynapseE2ETest):
@@ -483,6 +484,354 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
             )
             self.assertNotEqual(login_response.status_code, 200)
         finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    # ---- CMS feedback-log delete tests ----
+
+    async def test_delete_user_removes_cms_feedback_logs(self):
+        """Seed 2 logs → force delete → response reports 2 deleted, mock confirms."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            cms_url = mock_cms.start()
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "cms_base_url": cms_url,
+                    "cms_service_api_key": "test-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="delcms",
+                password="pw1",
+                admin=False,
+            )
+            _, access_token = await self.login_user("delcms", "pw1")
+            user_id = "@delcms:my.domain.name"
+
+            mock_cms.seed_feedback_logs(
+                user_id,
+                [
+                    {"id": "fb1", "req": {"user_id": user_id}},
+                    {"id": "fb2", "req": {"user_id": user_id}},
+                ],
+            )
+
+            delete_url = "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            requests.post(
+                delete_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            force = requests.post(
+                delete_url,
+                json={"action": "force"},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(force.status_code, 200)
+            self.assertEqual(force.json()["deleted_cms_feedback_logs"], 2)
+            self.assertEqual(mock_cms.get_remaining_logs(user_id), [])
+        finally:
+            mock_cms.stop()
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_delete_user_reports_zero_when_no_feedback_logs(self):
+        """No seeded data → deleted_cms_feedback_logs: 0."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            cms_url = mock_cms.start()
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "cms_base_url": cms_url,
+                    "cms_service_api_key": "test-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="nocms",
+                password="pw1",
+                admin=False,
+            )
+            _, access_token = await self.login_user("nocms", "pw1")
+
+            delete_url = "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            requests.post(
+                delete_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            force = requests.post(
+                delete_url,
+                json={"action": "force"},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(force.status_code, 200)
+            self.assertEqual(force.json()["deleted_cms_feedback_logs"], 0)
+        finally:
+            mock_cms.stop()
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_delete_user_succeeds_when_cms_unavailable(self):
+        """Dead CMS URL → account still deactivated, feedback logs = 0."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "cms_base_url": "http://127.0.0.1:9",
+                    "cms_service_api_key": "test-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="deadcms",
+                password="pw1",
+                admin=False,
+            )
+            _, access_token = await self.login_user("deadcms", "pw1")
+
+            delete_url = "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            requests.post(
+                delete_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            force = requests.post(
+                delete_url,
+                json={"action": "force"},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(force.status_code, 200)
+            self.assertEqual(force.json()["deleted_cms_feedback_logs"], 0)
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "deadcms",
+                    "password": "pw1",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_scheduled_delete_removes_cms_feedback_logs(self):
+        """Seed data + short delay + fast processor → logs gone & account deactivated."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            cms_url = mock_cms.start()
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "delete_user_schedule_delay_seconds": 3,
+                    "delete_user_processor_interval_seconds": 1,
+                    "cms_base_url": cms_url,
+                    "cms_service_api_key": "test-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="schedcms",
+                password="pw1",
+                admin=False,
+            )
+            _, access_token = await self.login_user("schedcms", "pw1")
+            user_id = "@schedcms:my.domain.name"
+
+            mock_cms.seed_feedback_logs(
+                user_id,
+                [{"id": "sc1", "req": {"user_id": user_id}}],
+            )
+
+            delete_url = "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            schedule_resp = requests.post(
+                delete_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            self.assertEqual(schedule_resp.status_code, 200)
+
+            await asyncio.sleep(6)
+
+            self.assertEqual(mock_cms.get_remaining_logs(user_id), [])
+            self.assertEqual(self._count_schedules(config_path, user_id), 0)
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "schedcms",
+                    "password": "pw1",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            mock_cms.stop()
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_admin_force_delete_removes_other_users_feedback_logs(self):
+        """Admin deletes target → target's feedback logs removed."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            cms_url = mock_cms.start()
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "cms_base_url": cms_url,
+                    "cms_service_api_key": "test-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admindel",
+                password="pw1",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="victimcms",
+                password="pw2",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admindel", "pw1")
+            target_user_id = "@victimcms:my.domain.name"
+
+            mock_cms.seed_feedback_logs(
+                target_user_id,
+                [
+                    {"id": "v1", "req": {"user_id": target_user_id}},
+                    {"id": "v2", "req": {"user_id": target_user_id}},
+                    {"id": "v3", "req": {"user_id": target_user_id}},
+                ],
+            )
+
+            delete_url = "http://localhost:8008/_synapse/client/pangea/v1/delete_user"
+            requests.post(
+                delete_url,
+                json={"user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            force = requests.post(
+                delete_url,
+                json={"action": "force", "user_id": target_user_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            self.assertEqual(force.status_code, 200)
+            self.assertEqual(force.json()["deleted_cms_feedback_logs"], 3)
+            self.assertEqual(mock_cms.get_remaining_logs(target_user_id), [])
+
+            login_url = "http://localhost:8008/_matrix/client/v3/login"
+            login_response = requests.post(
+                login_url,
+                json={
+                    "type": "m.login.password",
+                    "user": "victimcms",
+                    "password": "pw2",
+                },
+            )
+            self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            mock_cms.stop()
             self.stop_synapse(
                 server_process=server_process,
                 stdout_thread=stdout_thread,

--- a/tests/test_export_user_data_e2e.py
+++ b/tests/test_export_user_data_e2e.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -8,6 +9,7 @@ import yaml
 from psycopg2 import connect
 
 from .base_e2e import BaseSynapseE2ETest
+from .mock_cms_server import MockCmsServer
 
 
 class TestExportUserDataE2E(BaseSynapseE2ETest):
@@ -1008,6 +1010,378 @@ class TestExportUserDataE2E(BaseSynapseE2ETest):
                     expected_body="disk should still work",
                 )
             finally:
+                self.stop_synapse(
+                    server_process=server_process,
+                    stdout_thread=stdout_thread,
+                    stderr_thread=stderr_thread,
+                    synapse_dir=synapse_dir,
+                    postgres=postgres,
+                )
+
+    # ---- CMS feedback-log tests ----
+
+    async def test_export_includes_cms_feedback_logs_in_zip(self):
+        """Seed 3 feedback logs → admin force export → ZIP contains them."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            try:
+                cms_url = mock_cms.start()
+                (
+                    postgres,
+                    synapse_dir,
+                    config_path,
+                    server_process,
+                    stdout_thread,
+                    stderr_thread,
+                ) = await self.start_test_synapse(
+                    module_config={
+                        "export_user_data_processor_interval_seconds": 60,
+                        "export_user_data_output_dir": export_dir,
+                        "cms_base_url": cms_url,
+                        "cms_service_api_key": "test-key",
+                    }
+                )
+
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="admin",
+                    password="pw1",
+                    admin=True,
+                )
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="fbuser",
+                    password="pw2",
+                    admin=False,
+                )
+                _, admin_token = await self.login_user("admin", "pw1")
+                user_id, _ = await self.login_user("fbuser", "pw2")
+
+                mock_cms.seed_feedback_logs(
+                    user_id,
+                    [
+                        {"id": "1", "req": {"user_id": user_id}, "data": "a"},
+                        {"id": "2", "req": {"user_id": user_id}, "data": "b"},
+                        {"id": "3", "req": {"user_id": user_id}, "data": "c"},
+                    ],
+                )
+
+                requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "schedule", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                force = requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "force", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                self.assertEqual(force.status_code, 200)
+
+                zip_path = self._zip_path_for_user(export_dir, user_id)
+                user_data = self._read_export_json(zip_path)
+                logs = user_data.get("cms_process_token_feedback_logs", [])
+                self.assertEqual(len(logs), 3)
+                self.assertEqual({doc["id"] for doc in logs}, {"1", "2", "3"})
+            finally:
+                mock_cms.stop()
+                self.stop_synapse(
+                    server_process=server_process,
+                    stdout_thread=stdout_thread,
+                    stderr_thread=stderr_thread,
+                    synapse_dir=synapse_dir,
+                    postgres=postgres,
+                )
+
+    async def test_export_includes_empty_feedback_logs_when_user_has_none(self):
+        """No seeded data → export contains empty list."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            try:
+                cms_url = mock_cms.start()
+                (
+                    postgres,
+                    synapse_dir,
+                    config_path,
+                    server_process,
+                    stdout_thread,
+                    stderr_thread,
+                ) = await self.start_test_synapse(
+                    module_config={
+                        "export_user_data_processor_interval_seconds": 60,
+                        "export_user_data_output_dir": export_dir,
+                        "cms_base_url": cms_url,
+                        "cms_service_api_key": "test-key",
+                    }
+                )
+
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="admin",
+                    password="pw1",
+                    admin=True,
+                )
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="nofb",
+                    password="pw2",
+                    admin=False,
+                )
+                _, admin_token = await self.login_user("admin", "pw1")
+                user_id, _ = await self.login_user("nofb", "pw2")
+
+                requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "schedule", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                force = requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "force", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                self.assertEqual(force.status_code, 200)
+
+                zip_path = self._zip_path_for_user(export_dir, user_id)
+                user_data = self._read_export_json(zip_path)
+                self.assertEqual(user_data.get("cms_process_token_feedback_logs"), [])
+            finally:
+                mock_cms.stop()
+                self.stop_synapse(
+                    server_process=server_process,
+                    stdout_thread=stdout_thread,
+                    stderr_thread=stderr_thread,
+                    synapse_dir=synapse_dir,
+                    postgres=postgres,
+                )
+
+    async def test_export_paginates_feedback_logs(self):
+        """Seed items exceeding a single page → all appear in export.
+
+        The mock returns pages of configurable size via the limit param.
+        We seed 5 items and the export code uses limit=100 by default,
+        so all appear in one page. This test verifies the pagination loop
+        handles the hasNextPage=false termination correctly.
+        """
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            try:
+                cms_url = mock_cms.start()
+                (
+                    postgres,
+                    synapse_dir,
+                    config_path,
+                    server_process,
+                    stdout_thread,
+                    stderr_thread,
+                ) = await self.start_test_synapse(
+                    module_config={
+                        "export_user_data_processor_interval_seconds": 60,
+                        "export_user_data_output_dir": export_dir,
+                        "cms_base_url": cms_url,
+                        "cms_service_api_key": "test-key",
+                    }
+                )
+
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="admin",
+                    password="pw1",
+                    admin=True,
+                )
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="pager",
+                    password="pw2",
+                    admin=False,
+                )
+                _, admin_token = await self.login_user("admin", "pw1")
+                user_id, _ = await self.login_user("pager", "pw2")
+
+                mock_cms.seed_feedback_logs(
+                    user_id,
+                    [{"id": str(i), "req": {"user_id": user_id}} for i in range(5)],
+                )
+
+                requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "schedule", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                force = requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "force", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                self.assertEqual(force.status_code, 200)
+
+                zip_path = self._zip_path_for_user(export_dir, user_id)
+                user_data = self._read_export_json(zip_path)
+                logs = user_data.get("cms_process_token_feedback_logs", [])
+                self.assertEqual(len(logs), 5)
+            finally:
+                mock_cms.stop()
+                self.stop_synapse(
+                    server_process=server_process,
+                    stdout_thread=stdout_thread,
+                    stderr_thread=stderr_thread,
+                    synapse_dir=synapse_dir,
+                    postgres=postgres,
+                )
+
+    async def test_export_succeeds_when_cms_unavailable(self):
+        """Dead CMS URL → ZIP still valid with empty feedback-logs array."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            try:
+                (
+                    postgres,
+                    synapse_dir,
+                    config_path,
+                    server_process,
+                    stdout_thread,
+                    stderr_thread,
+                ) = await self.start_test_synapse(
+                    module_config={
+                        "export_user_data_processor_interval_seconds": 60,
+                        "export_user_data_output_dir": export_dir,
+                        "cms_base_url": "http://127.0.0.1:9",
+                        "cms_service_api_key": "test-key",
+                    }
+                )
+
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="admin",
+                    password="pw1",
+                    admin=True,
+                )
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="deadcms",
+                    password="pw2",
+                    admin=False,
+                )
+                _, admin_token = await self.login_user("admin", "pw1")
+                user_id, _ = await self.login_user("deadcms", "pw2")
+
+                requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "schedule", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                force = requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "force", "user_id": user_id},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                self.assertEqual(force.status_code, 200)
+
+                zip_path = self._zip_path_for_user(export_dir, user_id)
+                user_data = self._read_export_json(zip_path)
+                self.assertEqual(user_data.get("cms_process_token_feedback_logs"), [])
+            finally:
+                self.stop_synapse(
+                    server_process=server_process,
+                    stdout_thread=stdout_thread,
+                    stderr_thread=stderr_thread,
+                    synapse_dir=synapse_dir,
+                    postgres=postgres,
+                )
+
+    async def test_scheduled_export_includes_feedback_logs(self):
+        """Seed data, background processor (interval=1s) → ZIP has feedback logs."""
+        mock_cms = MockCmsServer()
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            try:
+                cms_url = mock_cms.start()
+                (
+                    postgres,
+                    synapse_dir,
+                    config_path,
+                    server_process,
+                    stdout_thread,
+                    stderr_thread,
+                ) = await self.start_test_synapse(
+                    module_config={
+                        "export_user_data_processor_interval_seconds": 1,
+                        "export_user_data_output_dir": export_dir,
+                        "cms_base_url": cms_url,
+                        "cms_service_api_key": "test-key",
+                    }
+                )
+
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user="schedexp",
+                    password="pw1",
+                    admin=False,
+                )
+                user_id, user_token = await self.login_user("schedexp", "pw1")
+
+                mock_cms.seed_feedback_logs(
+                    user_id,
+                    [
+                        {"id": "s1", "req": {"user_id": user_id}},
+                        {"id": "s2", "req": {"user_id": user_id}},
+                    ],
+                )
+
+                response = requests.post(
+                    self._EXPORT_URL,
+                    json={"action": "schedule"},
+                    headers={"Authorization": f"Bearer {user_token}"},
+                )
+                self.assertEqual(response.status_code, 200)
+
+                await asyncio.sleep(8)
+
+                self.assertEqual(self._count_schedules(config_path, user_id), 0)
+
+                zip_path = self._zip_path_for_user(export_dir, user_id)
+                user_data = self._read_export_json(zip_path)
+                logs = user_data.get("cms_process_token_feedback_logs", [])
+                self.assertEqual(len(logs), 2)
+            finally:
+                mock_cms.stop()
                 self.stop_synapse(
                     server_process=server_process,
                     stdout_thread=stdout_thread,


### PR DESCRIPTION
## What

Add CMS process-token-feedback-logs to GDPR export and delete flows, with E2E coverage via a mock CMS server.

## Why

Closes #46

## Testing

- /Users/wilsonle/dev/pangea-chat/synapse-pangea-chat-modules/.venv/bin/python -m unittest tests.test_export_user_data_unit tests.test_export_user_data_e2e tests.test_delete_user_e2e -v
- Result: Ran 43 tests ... OK

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None
