### PR TITLE
feat(public-courses): expose stable route alias

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ For Synapse Admin API, Module API, and Matrix spec documentation links, see [syn
 
 Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) composes sub-modules. Each sub-module lives in its own sub-package under `synapse_pangea_chat/`.
 
-**Sub-modules**: `public_courses/`, `room_preview/`, `room_code/` ([design](.github/instructions/knock-with-code.instructions.md)), `delete_room/`, `user_activity/` ([design](.github/instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](.github/instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](.github/instructions/invite-by-email.instructions.md), [create_course_space](.github/instructions/create-course-space.instructions.md))
+**Sub-modules**: `public_courses/` ([design](.github/instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](.github/instructions/knock-with-code.instructions.md)), `delete_room/`, `user_activity/` ([design](.github/instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](.github/instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](.github/instructions/invite-by-email.instructions.md), [create_course_space](.github/instructions/create-course-space.instructions.md))
 
 ## Key Files
 

--- a/.github/instructions/public-courses.instructions.md
+++ b/.github/instructions/public-courses.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "synapse_pangea_chat/public_courses/**,synapse_pangea_chat/__init__.py,tests/test_room_preview_e2e.py,tests/staging_tests/staging_tests.py"
+---
+
+# Public Courses
+
+Public course discovery endpoint for course catalog surfaces in clients and operator tooling.
+
+## Route Contract
+
+- Canonical route: `GET /_synapse/client/pangea/v1/public_courses`
+- Compatibility route: `GET /_synapse/client/unstable/org.pangea/public_courses`
+- Both routes must be registered to the same resource and return identical payloads.
+- New callers should use the canonical `pangea/v1` route.
+
+## Behavior
+
+- Auth uses Matrix bearer tokens.
+- Rate limiting behavior is shared across both routes.
+- Query params and response schema must stay identical across aliases.
+- Filtering behavior is defined by the shared `PublicCourses` resource and must not diverge by path.
+
+## Compatibility
+
+- Keep the unstable alias until all known callers and tests are migrated.
+- When the canonical route changes, update operator tooling, bot callers, tests, and README references in the same session.
+
+## Future Work
+
+_(No linked issues yet.)_

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unified [Synapse](https://github.com/element-hq/synapse) module that bundles all
 
 | Module                                        | Subpackage                                  | Endpoint                                                  | Description                                       |
 | --------------------------------------------- | ------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------- |
-| [Public Courses](#public-courses)             | `synapse_pangea_chat/`                      | `GET /_synapse/client/unstable/org.pangea/public_courses` | Course catalog with filtering and pagination      |
+| [Public Courses](#public-courses)             | `synapse_pangea_chat/`                      | `GET /_synapse/client/pangea/v1/public_courses`           | Course catalog with filtering and pagination      |
 | [Room Preview](#room-preview)                 | `synapse_pangea_chat/room_preview/`         | `GET /_synapse/client/unstable/org.pangea/room_preview`   | Read room state events without membership         |
 | [Room Code](#room-code)                       | `synapse_pangea_chat/room_code/`            | `POST /_synapse/client/pangea/v1/knock_with_code`         | Secret-code-based room invitations                |
 |                                               |                                             | `GET /_synapse/client/pangea/v1/request_room_code`        | Generate a unique room access code                |
@@ -71,7 +71,9 @@ All config keys are optional and have sensible defaults. The `limit_user_directo
 
 Surface curated course previews via a dedicated HTTP endpoint with built-in filtering and rate limiting.
 
-**Route:** `GET /_synapse/client/unstable/org.pangea/public_courses`
+**Canonical route:** `GET /_synapse/client/pangea/v1/public_courses`
+
+**Compatibility route:** `GET /_synapse/client/unstable/org.pangea/public_courses`
 
 ### Authentication
 

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -68,6 +68,10 @@ class PangeaChat:
         # --- Public Courses ---
         self.public_courses = PublicCourses(api, config)
         self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/public_courses",
+            resource=self.public_courses,
+        )
+        self._api.register_web_resource(
             path="/_synapse/client/unstable/org.pangea/public_courses",
             resource=self.public_courses,
         )

--- a/tests/staging_tests/CHANGELOG.md
+++ b/tests/staging_tests/CHANGELOG.md
@@ -73,7 +73,8 @@ Consolidated 6 separate Synapse module entries into the single `synapse_pangea_c
 
 After deploying to staging, verify each feature still works through the unified module:
 
-#### 1. Public Courses — `GET /_synapse/client/unstable/org.pangea/public_courses`
+#### 1. Public Courses — `GET /_synapse/client/pangea/v1/public_courses`
+- Compatibility alias: `GET /_synapse/client/unstable/org.pangea/public_courses`
 - [ ] Authenticated request returns a list of public courses with `chunk`, `next_batch`, `prev_batch`, `total_room_count_estimate`
 - [ ] Each course has: `room_id`, `name`, `topic`, `avatar_url`, `canonical_alias`, `course_id`, `num_joined_members`, `world_readable`, `guest_can_join`, `join_rule`, `room_type`
 - [ ] `course_id` matches the `uuid` field from the room's `pangea.course_plan` state event

--- a/tests/staging_tests/staging_tests.py
+++ b/tests/staging_tests/staging_tests.py
@@ -113,7 +113,7 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
     # helper: fetch first public course room_id (or skip)
     async def _first_public_course_room_id(self) -> str:
         resp = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses",
+            "/_synapse/client/pangea/v1/public_courses",
             params={"limit": "1"},
         )
         self.assertEqual(resp.status, 200)
@@ -129,13 +129,20 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_public_courses_requires_auth(self) -> None:
         """Unauthenticated request → 401."""
-        resp = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses", auth=False
-        )
+        resp = await self._get("/_synapse/client/pangea/v1/public_courses", auth=False)
         self.assertEqual(resp.status, 401)
 
     async def test_public_courses_returns_valid_structure(self) -> None:
         """Response contains chunk, next_batch, prev_batch, total_room_count_estimate."""
+        resp = await self._get("/_synapse/client/pangea/v1/public_courses")
+        self.assertEqual(resp.status, 200)
+        data = await resp.json()
+        for key in ("chunk", "next_batch", "prev_batch", "total_room_count_estimate"):
+            self.assertIn(key, data, f"Missing top-level key: {key}")
+        self.assertIsInstance(data["chunk"], list)
+
+    async def test_public_courses_unstable_alias_returns_valid_structure(self) -> None:
+        """Compatibility alias returns the same top-level response shape."""
         resp = await self._get("/_synapse/client/unstable/org.pangea/public_courses")
         self.assertEqual(resp.status, 200)
         data = await resp.json()
@@ -146,7 +153,7 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
     async def test_public_courses_course_fields(self) -> None:
         """Every course has the full set of expected keys."""
         resp = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses",
+            "/_synapse/client/pangea/v1/public_courses",
             params={"limit": "5"},
         )
         self.assertEqual(resp.status, 200)
@@ -174,7 +181,7 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
     async def test_public_courses_pagination(self) -> None:
         """limit / since pagination returns successive pages."""
         resp = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses",
+            "/_synapse/client/pangea/v1/public_courses",
             params={"limit": "1"},
         )
         self.assertEqual(resp.status, 200)
@@ -186,7 +193,7 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
             self.skipTest("Only one page of courses — pagination not testable")
 
         resp2 = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses",
+            "/_synapse/client/pangea/v1/public_courses",
             params={"limit": "1", "since": str(next_batch)},
         )
         self.assertEqual(resp2.status, 200)
@@ -199,7 +206,7 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
 
         # Fetch the course_id from public_courses
         resp = await self._get(
-            "/_synapse/client/unstable/org.pangea/public_courses",
+            "/_synapse/client/pangea/v1/public_courses",
             params={"limit": "50"},
         )
         self.assertEqual(resp.status, 200)

--- a/tests/test_room_preview_e2e.py
+++ b/tests/test_room_preview_e2e.py
@@ -1910,7 +1910,7 @@ class TestE2E(BaseSynapseE2ETest):
             matching_courses: List[Dict[str, Any]] = []
             for _ in range(10):
                 public_courses_response = requests.get(
-                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses",
+                    f"{self.server_url}/_synapse/client/pangea/v1/public_courses",
                     headers=headers,
                     timeout=30,
                 )
@@ -2089,7 +2089,7 @@ class TestE2E(BaseSynapseE2ETest):
             matching_courses: List[Dict[str, Any]] = []
             for _ in range(10):
                 public_courses_response = requests.get(
-                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses",
+                    f"{self.server_url}/_synapse/client/pangea/v1/public_courses",
                     headers=headers,
                     timeout=30,
                 )
@@ -2219,7 +2219,7 @@ class TestE2E(BaseSynapseE2ETest):
             payload = None
             for _ in range(10):
                 response = requests.get(
-                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses",
+                    f"{self.server_url}/_synapse/client/pangea/v1/public_courses",
                     headers=headers,
                     timeout=30,
                 )
@@ -2331,7 +2331,7 @@ class TestE2E(BaseSynapseE2ETest):
             payload = None
             for _ in range(10):
                 response = requests.get(
-                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses?target_language=es",
+                    f"{self.server_url}/_synapse/client/pangea/v1/public_courses?target_language=es",
                     headers=headers,
                     timeout=30,
                 )
@@ -2559,7 +2559,7 @@ class TestE2E(BaseSynapseE2ETest):
             matching_courses: List[Dict[str, Any]] = []
             for _ in range(10):
                 public_courses_response = requests.get(
-                    f"{self.server_url}/_synapse/client/unstable/org.pangea/public_courses",
+                    f"{self.server_url}/_synapse/client/pangea/v1/public_courses",
                     headers=headers,
                     timeout=30,
                 )


### PR DESCRIPTION
## What
- expose `/_synapse/client/pangea/v1/public_courses`
- keep the unstable `org.pangea` route as a compatibility alias
- update docs and tests for the endpoint contract

## Why
Closes #56

## Testing
- `python -m twisted.trial tests`
- staging smoke tests not run: `SYNAPSE_BASE_URL` and `SYNAPSE_AUTH_TOKEN` were not set in this shell
- `black --check synapse_pangea_chat tests` currently fails on unrelated pre-existing formatting in `synapse_pangea_chat/room_code/burn_admin_code.py`
- `ruff check synapse_pangea_chat tests` currently fails on unrelated pre-existing unused imports in `synapse_pangea_chat/email_invite/create_course_space.py` and `synapse_pangea_chat/email_invite/invite_by_email.py`

### Tested on:
- [ ] Staging
- [ ] Production

## Deploy Notes
None