### PR TITLE
fix(compat): support synapse 1.124.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ For Synapse Admin API, Module API, and Matrix spec documentation links, see [syn
 
 Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) composes sub-modules. Each sub-module lives in its own sub-package under `synapse_pangea_chat/`.
 
-**Sub-modules**: `public_courses/` ([design](.github/instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](.github/instructions/knock-with-code.instructions.md)), `delete_room/`, `user_activity/` ([design](.github/instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](.github/instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](.github/instructions/invite-by-email.instructions.md), [create_course_space](.github/instructions/create-course-space.instructions.md))
+**Sub-modules**: `public_courses/` ([design](instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](instructions/knock-with-code.instructions.md)), `delete_room/`, `delete_user/` + `export_user_data/` ([design](instructions/delete-user-export-user-data.instructions.md)), `user_activity/` ([design](instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](instructions/invite-by-email.instructions.md), [create_course_space](instructions/create-course-space.instructions.md)), `register_email/` ([design](instructions/register-email.instructions.md))
 
 ## Key Files
 

--- a/.github/instructions/delete-user-export-user-data.instructions.md
+++ b/.github/instructions/delete-user-export-user-data.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "synapse_pangea_chat/delete_user/**,synapse_pangea_chat/export_user_data/**,synapse_pangea_chat/__init__.py,tests/test_delete_user_e2e.py,tests/test_export_user_data_e2e.py,tests/test_export_user_data_unit.py"
+---
+
+# Delete User & Export User Data
+
+Two admin-adjacent Pangea endpoints extend Synapse with controlled account lifecycle operations:
+
+- `/_synapse/client/pangea/v1/delete_user` schedules, cancels, or forces local account deletion.
+- `/_synapse/client/pangea/v1/export_user_data` schedules, cancels, forces, or inspects local data export jobs.
+
+## Compatibility Contract
+
+- These endpoints must remain available on Synapse `1.124.0` and newer.
+- Compatibility must be gated by the actual capability each endpoint needs, not by broad version checks.
+- If a newer Synapse helper is unavailable on older supported versions, prefer a local compatibility shim over disabling the endpoint.
+- `COMPAT.yml` must only declare a minimum Synapse version when a real, audited incompatibility remains.
+
+## Request Model
+
+- Both endpoints accept authenticated `POST` requests with JSON bodies.
+- `delete_user` supports `schedule`, `cancel`, and `force`.
+- `export_user_data` supports `schedule`, `cancel`, `force`, and `status`.
+- Omitting `user_id` targets the requester.
+- Remote users must be rejected; these flows are only for local accounts.
+
+## Authorization
+
+- Users may operate on their own account/export.
+- Targeting another user requires Synapse admin privileges.
+- Invalid or missing access tokens must return the same authentication semantics as the rest of the module surface.
+
+## Scheduling Behavior
+
+- Both features maintain durable schedule state in Synapse's database so work survives process restarts.
+- Scheduled work is processed asynchronously on a recurring background loop.
+- The scheduling mechanism must preserve existing behavior across supported Synapse versions, including short test-time intervals.
+- Repeated force runs should be idempotent at the API contract level: callers receive a successful operation rather than a route-level failure when the feature is enabled.
+
+## Side Effects
+
+- `delete_user` must deactivate the Matrix account and remove related CMS feedback-log artifacts when configured.
+- `export_user_data` must produce a complete export payload, including CMS feedback logs when available, and degrade gracefully when CMS is unavailable.
+- Failures in optional downstream cleanup or upload work must not silently disable the endpoint itself.
+
+## Registration
+
+- `PangeaChat` must register both endpoints whenever their required runtime capabilities are present on supported Synapse versions.
+- Logging may explain degraded behavior, but supported versions must not lose the route entirely due to optional helper imports.
+
+## Key Files
+
+- Endpoint registration: [synapse_pangea_chat/__init__.py](../../synapse_pangea_chat/__init__.py)
+- Delete user: [synapse_pangea_chat/delete_user/delete_user.py](../../synapse_pangea_chat/delete_user/delete_user.py)
+- Export user data: [synapse_pangea_chat/export_user_data/export_user_data.py](../../synapse_pangea_chat/export_user_data/export_user_data.py)
+- Config: [synapse_pangea_chat/config.py](../../synapse_pangea_chat/config.py)
+- Tests: [tests/test_delete_user_e2e.py](../../tests/test_delete_user_e2e.py), [tests/test_export_user_data_e2e.py](../../tests/test_export_user_data_e2e.py), [tests/test_export_user_data_unit.py](../../tests/test_export_user_data_unit.py)
+
+## Future Work
+
+_Last updated: 2026-03-20_
+
+**Privacy & Compliance**
+
+- [pangeachat/security#26](https://github.com/pangeachat/security/issues/26) — Build JSON data export tooling
+- [pangeachat/security#47](https://github.com/pangeachat/security/issues/47) — W40: Client does not pass erase:true on account deactivation

--- a/.github/instructions/register-email.instructions.md
+++ b/.github/instructions/register-email.instructions.md
@@ -1,0 +1,44 @@
+---
+applyTo: "synapse_pangea_chat/register_email/**,synapse_pangea_chat/__init__.py,tests/test_register_email_e2e.py"
+---
+
+# Register Email Request Token
+
+Pangea exposes a registration-email endpoint that validates the requested username before Synapse sends a verification email.
+
+## Route Contract
+
+- Canonical route: `POST /_synapse/client/pangea/v1/register/email/requestToken`
+- The route stays unauthenticated because it is part of account creation.
+- The request body must include `username`, `client_secret`, `email`, and `send_attempt`.
+- `next_link` is optional and should retain Synapse-compatible behavior.
+
+## Behavior
+
+- Username validation happens before any email-side effect so we never send a verification email for a taken or invalid username.
+- Missing or invalid request parameters must preserve Matrix-compatible error semantics.
+- IP-based rate limiting is part of the endpoint contract because the route is unauthenticated.
+- The endpoint should delegate to Synapse's existing threepid validation flow once Pangea-specific username checks pass.
+
+## Email Configuration
+
+- If Synapse email verification is disabled, the route must remain registered and return a clear error instead of disappearing.
+- When email verification is enabled, this endpoint must use Synapse's registration mailer/templates rather than a separate mail pipeline.
+- Existing Synapse protections around threepid allowlists, existing email ownership, and idempotent resend behavior must remain intact.
+
+## Compatibility
+
+- Keep the endpoint behavior aligned with Synapse's built-in `register/email/requestToken` flow wherever Pangea is not intentionally adding policy.
+- Type-only or test-only fixes should prefer local narrowing and annotations over behavior changes.
+
+## Key Files
+
+- Endpoint registration: [synapse_pangea_chat/__init__.py](../../synapse_pangea_chat/__init__.py)
+- Endpoint implementation: [synapse_pangea_chat/register_email/register_email.py](../../synapse_pangea_chat/register_email/register_email.py)
+- End-to-end tests: [tests/test_register_email_e2e.py](../../tests/test_register_email_e2e.py)
+
+## Future Work
+
+_Last updated: 2026-03-20_
+
+_(No linked issues or discussions yet.)_

--- a/COMPAT.yml
+++ b/COMPAT.yml
@@ -5,5 +5,5 @@
 # If this file is absent in a given commit, any Synapse version is assumed compatible.
 # Do not lower min_synapse_version without auditing all sub-module imports first.
 
-min_synapse_version: "1.148.0"
-reason: "delete_user uses synapse.util.duration, which does not exist in Synapse < 1.148.0 (confirmed broken on 1.124.0, confirmed working on 1.148.0)"
+min_synapse_version: "1.124.0"
+reason: "delete_user and export_user_data were audited against Synapse 1.124.0; their recurring background jobs now use the older clock.looping_call millisecond interval supported there"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = ["attrs"]
 [project.optional-dependencies]
 dev = [
   # for tests
-  "matrix-synapse",
+  "matrix-synapse == 1.124.0",
+  "prometheus-client == 0.22.1",
   "tox",
   "twisted == 24.7.0",
   "aiounittest",

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from typing import Any, Dict, Mapping, Tuple
 
@@ -7,27 +6,9 @@ from synapse.module_api import ModuleApi
 
 from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.delete_room import DeleteRoom
+from synapse_pangea_chat.delete_user import DeleteUser
 from synapse_pangea_chat.email_invite import CreateCourseSpace, InviteByEmail
-
-try:
-    from synapse_pangea_chat.delete_user import DeleteUser
-
-    _DELETE_USER_AVAILABLE = True
-    _delete_user_import_err = ""
-except ImportError as e:
-    # Requires Synapse >= 1.148.0.  Older installations skip this sub-module
-    # rather than crashing all of Synapse.  See COMPAT.yml.
-    _DELETE_USER_AVAILABLE = False
-    _delete_user_import_err = str(e)
-try:
-    from synapse_pangea_chat.export_user_data import ExportUserData
-
-    _EXPORT_USER_DATA_AVAILABLE = True
-    _export_user_data_import_err = ""
-except ImportError as e:
-    # Requires Synapse >= 1.148.0 (same Duration dependency as delete_user).
-    _EXPORT_USER_DATA_AVAILABLE = False
-    _export_user_data_import_err = str(e)
+from synapse_pangea_chat.export_user_data import ExportUserData
 from synapse_pangea_chat.limit_user_directory import LimitUserDirectory
 from synapse_pangea_chat.public_courses import PublicCourses
 from synapse_pangea_chat.register_email import RegisterEmailRequestToken
@@ -45,8 +26,6 @@ from synapse_pangea_chat.user_activity import (
     UserCourses,
 )
 from synapse_pangea_chat.user_directory_search import UserDirectorySearch
-
-logger = logging.getLogger(f"synapse.module.{__name__}")
 
 
 class PangeaChat:
@@ -121,28 +100,19 @@ class PangeaChat:
             resource=self.delete_room_resource,
         )
 
-        # --- Delete User (requires Synapse >= 1.148.0, see COMPAT.yml) ---
-        if _DELETE_USER_AVAILABLE:
-            self.delete_user_resource = DeleteUser(api, config)
-            self._api.register_web_resource(
-                path="/_synapse/client/pangea/v1/delete_user",
-                resource=self.delete_user_resource,
-            )
-        else:
-            logger.warning("delete_user endpoint disabled: %s", _delete_user_import_err)
+        # --- Delete User ---
+        self.delete_user_resource = DeleteUser(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/delete_user",
+            resource=self.delete_user_resource,
+        )
 
-        # --- Export User Data (requires Synapse >= 1.148.0, see COMPAT.yml) ---
-        if _EXPORT_USER_DATA_AVAILABLE:
-            self.export_user_data_resource = ExportUserData(api, config)
-            self._api.register_web_resource(
-                path="/_synapse/client/pangea/v1/export_user_data",
-                resource=self.export_user_data_resource,
-            )
-        else:
-            logger.warning(
-                "export_user_data endpoint disabled: %s",
-                _export_user_data_import_err,
-            )
+        # --- Export User Data ---
+        self.export_user_data_resource = ExportUserData(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/export_user_data",
+            resource=self.export_user_data_resource,
+        )
 
         # --- User Activity ---
         self.user_activity_resource = UserActivity(api, config)

--- a/synapse_pangea_chat/delete_user/delete_user.py
+++ b/synapse_pangea_chat/delete_user/delete_user.py
@@ -15,20 +15,9 @@ from synapse.api.errors import (
 from synapse.http import server
 from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
+from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.module_api import ModuleApi
 from synapse.types import create_requester
-
-try:
-    from synapse.util.duration import Duration
-except ImportError:
-    import synapse as _synapse
-
-    raise ImportError(
-        f"synapse_pangea_chat.delete_user requires Synapse >= 1.148.0 "
-        f"(synapse.util.duration is not available in Synapse {_synapse.__version__}). "
-        f"Either upgrade Synapse or pin synapse-pangea-chat to commit 9d9d411 "
-        f"(the last commit before delete_user was added)."
-    ) from None
 from twisted.internet import defer
 from twisted.web.resource import Resource
 
@@ -62,10 +51,10 @@ class DeleteUser(Resource):
         self._schedule_table_ready = False
 
         self._clock.looping_call(
-            self._api._hs.run_as_background_process,
-            Duration(seconds=self._config.delete_user_processor_interval_seconds),
-            desc="pangea_delete_user_process_schedules",
-            func=self._process_scheduled_deletes,
+            run_as_background_process,
+            self._config.delete_user_processor_interval_seconds * 1000,
+            "pangea_delete_user_process_schedules",
+            self._process_scheduled_deletes,
         )
 
     def render_POST(self, request: SynapseRequest):

--- a/synapse_pangea_chat/email_invite/create_course_space.py
+++ b/synapse_pangea_chat/email_invite/create_course_space.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict
 if TYPE_CHECKING:
     from synapse_pangea_chat.config import PangeaChatConfig
 
-from synapse.api.constants import EventTypes, Membership, RoomCreationPreset
+from synapse.api.constants import EventTypes, RoomCreationPreset
 from synapse.api.errors import (
     AuthError,
     InvalidClientCredentialsError,

--- a/synapse_pangea_chat/email_invite/invite_by_email.py
+++ b/synapse_pangea_chat/email_invite/invite_by_email.py
@@ -7,7 +7,7 @@ to join a Matrix room via its access code join link.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 if TYPE_CHECKING:
     from synapse_pangea_chat.config import PangeaChatConfig

--- a/synapse_pangea_chat/export_user_data/export_user_data.py
+++ b/synapse_pangea_chat/export_user_data/export_user_data.py
@@ -21,20 +21,9 @@ from synapse.http import server
 from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
 from synapse.media.filepath import MediaFilePaths
+from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.module_api import ModuleApi
 from synapse.types import JsonMapping, StateMap
-
-try:
-    from synapse.util.duration import Duration
-except ImportError:
-    import synapse as _synapse
-
-    raise ImportError(
-        f"synapse_pangea_chat.export_user_data requires Synapse >= 1.148.0 "
-        f"(synapse.util.duration is not available in Synapse {_synapse.__version__}). "
-        f"Either upgrade Synapse or pin synapse-pangea-chat to commit 9d9d411 "
-        f"(the last commit before export_user_data was added)."
-    ) from None
 from twisted.internet import defer
 from twisted.web.resource import Resource
 
@@ -144,10 +133,10 @@ class ExportUserData(Resource):
         self._filepaths = MediaFilePaths(media_store_path)
 
         self._clock.looping_call(
-            self._api._hs.run_as_background_process,
-            Duration(seconds=self._config.export_user_data_processor_interval_seconds),
-            desc="pangea_export_user_data_process_schedules",
-            func=self._process_scheduled_exports,
+            run_as_background_process,
+            self._config.export_user_data_processor_interval_seconds * 1000,
+            "pangea_export_user_data_process_schedules",
+            self._process_scheduled_exports,
         )
 
     def render_POST(self, request: SynapseRequest):
@@ -553,9 +542,7 @@ class ExportUserData(Resource):
                 {
                     b"Content-Type": [b"application/json"],
                     b"Authorization": [
-                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode(
-                            "utf-8"
-                        )
+                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode("utf-8")
                     ],
                 }
             ),
@@ -595,9 +582,7 @@ class ExportUserData(Resource):
             Headers(
                 {
                     b"Authorization": [
-                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode(
-                            "utf-8"
-                        )
+                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode("utf-8")
                     ],
                 }
             ),
@@ -649,9 +634,7 @@ class ExportUserData(Resource):
                 {
                     b"Content-Type": [b"application/json"],
                     b"Authorization": [
-                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode(
-                            "utf-8"
-                        )
+                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode("utf-8")
                     ],
                 }
             ),
@@ -710,9 +693,7 @@ class ExportUserData(Resource):
                         )
                     ],
                     b"Authorization": [
-                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode(
-                            "utf-8"
-                        )
+                        f"{CMS_AUTH_COLLECTION} API-Key {cms_api_key}".encode("utf-8")
                     ],
                 }
             ),

--- a/synapse_pangea_chat/register_email/register_email.py
+++ b/synapse_pangea_chat/register_email/register_email.py
@@ -49,7 +49,7 @@ class RegisterEmailRequestToken(Resource):
         self._datastores = self._hs.get_datastores()
 
         if self._hs.config.email.can_verify_email:
-            self._registration_mailer = Mailer(
+            self._registration_mailer: Mailer | None = Mailer(
                 hs=self._hs,
                 app_name=self._hs.config.email.email_app_name,
                 template_html=self._hs.config.email.email_registration_template_html,

--- a/synapse_pangea_chat/room_code/burn_admin_code.py
+++ b/synapse_pangea_chat/room_code/burn_admin_code.py
@@ -66,11 +66,12 @@ async def burn_admin_code(api: ModuleApi, room_id: str, burner_user_id: str) -> 
             authenticated_entity=api.server_name,
         )
 
-        event, unpersisted_context = (
-            await event_creation_handler.create_new_client_event(
-                builder=builder,
-                requester=None,
-            )
+        (
+            event,
+            unpersisted_context,
+        ) = await event_creation_handler.create_new_client_event(
+            builder=builder,
+            requester=None,
         )
         context = await unpersisted_context.persist(event)
         await event_creation_handler._persist_events(

--- a/tests/mock_cms_server.py
+++ b/tests/mock_cms_server.py
@@ -11,7 +11,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 
-
 EXPECTED_AUTH_SCHEME = "service-users API-Key "
 
 
@@ -241,7 +240,9 @@ class _MockCmsState:
 
             return dict(doc)
 
-    def get_exports_for_matrix_user_id(self, matrix_user_id: str) -> List[Dict[str, Any]]:
+    def get_exports_for_matrix_user_id(
+        self, matrix_user_id: str
+    ) -> List[Dict[str, Any]]:
         with self._lock:
             return [
                 dict(doc)
@@ -279,7 +280,9 @@ class MockCmsServer:
     def seed_matrix_user(self, username: str) -> Dict[str, Any]:
         return self._state.seed_matrix_user(username)
 
-    def get_exports_for_matrix_user_id(self, matrix_user_id: str) -> List[Dict[str, Any]]:
+    def get_exports_for_matrix_user_id(
+        self, matrix_user_id: str
+    ) -> List[Dict[str, Any]]:
         return self._state.get_exports_for_matrix_user_id(matrix_user_id)
 
     def get_remaining_logs(self, user_id: str) -> List[Dict[str, Any]]:

--- a/tests/test_get_public_courses.py
+++ b/tests/test_get_public_courses.py
@@ -52,10 +52,12 @@ class TestGetPublicCourses(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(result, sentinel)
+        await_args = mock_unfiltered.await_args
+        assert await_args is not None
         # args: room_store, config, limit, start_index, total_room_count, ...
-        self.assertEqual(mock_unfiltered.await_args.args[2], 10)
-        self.assertEqual(mock_unfiltered.await_args.args[3], 0)
-        self.assertEqual(mock_unfiltered.await_args.args[4], 3)
+        self.assertEqual(await_args.args[2], 10)
+        self.assertEqual(await_args.args[3], 0)
+        self.assertEqual(await_args.args[4], 3)
         self.assertEqual(result["filtering_warning"], "")
 
     async def test_filtered_path_falls_back_when_cms_not_configured(self) -> None:

--- a/tests/test_limit_user_directory_e2e.py
+++ b/tests/test_limit_user_directory_e2e.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import subprocess
 import sys
@@ -58,6 +59,25 @@ class TestE2E(BaseSynapseE2ETest):
             self.assertIsInstance(user_id, str)
             users.append(user_id)
         return users
+
+    async def search_users_with_retry(
+        self,
+        search_term: str,
+        access_token: str,
+        *,
+        required_user_ids: List[str],
+        retries: int = 40,
+        delay_seconds: float = 0.5,
+    ) -> List[str]:
+        last_results: List[str] = []
+        required = set(required_user_ids)
+        for _ in range(retries):
+            last_results = await self.search_users(search_term, access_token)
+            if required.issubset(set(last_results)):
+                return last_results
+            await asyncio.sleep(delay_seconds)
+
+        return last_results
 
     async def get_public_attribute_of_user(
         self, user_id: str, access_token: str
@@ -184,8 +204,14 @@ class TestE2E(BaseSynapseE2ETest):
             (whitelisted_username, whitelisted_access_token) = await self.login_user(
                 "whitelisted", "password"
             )
-            users = await self.search_users("user", whitelisted_access_token)
-            self.assertEqual(len(users), 6)
+            for username, _access_token in creds:
+                localpart = username.split(":", 1)[0].lstrip("@")
+                users = await self.search_users_with_retry(
+                    localpart,
+                    whitelisted_access_token,
+                    required_user_ids=[username],
+                )
+                self.assertIn(username, users)
 
             # Shared room overrides private profile filtering.
             await self.register_user(
@@ -231,7 +257,12 @@ class TestE2E(BaseSynapseE2ETest):
             self.assertEqual(response.status_code, 200)
 
             # Search for userB as userA; shared room should allow userB to appear in the results.
-            users = await self.search_users("userB", tokenA)
+            user_b_localpart = userB.split(":", 1)[0].lstrip("@")
+            users = await self.search_users_with_retry(
+                user_b_localpart,
+                tokenA,
+                required_user_ids=[userB],
+            )
             self.assertIn(userB, users)
 
         finally:

--- a/tests/test_register_email_e2e.py
+++ b/tests/test_register_email_e2e.py
@@ -624,6 +624,11 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             self.smtp_server.stop()
             self.smtp_server = None
 
+    def _require_smtp_server(self) -> MockSMTPServer:
+        if self.smtp_server is None:
+            raise AssertionError("Mock SMTP server was not started")
+        return self.smtp_server
+
     async def test_happy_path_valid_username_and_email(self) -> None:
         """Valid username + valid email → 200 with sid."""
         postgres = synapse_dir = server_process = stdout_thread = stderr_thread = None
@@ -653,9 +658,10 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             self.assertTrue(len(body["sid"]) > 0)
 
             # Verify email was actually sent via mock SMTP
+            smtp_server = self._require_smtp_server()
             await asyncio.sleep(1)
             self.assertGreater(
-                len(self.smtp_server.received_emails),
+                len(smtp_server.received_emails),
                 0,
                 "Expected at least one email to be sent via SMTP",
             )
@@ -770,8 +776,9 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             self.assertEqual(resp1.status_code, 200, resp1.json())
             sid1 = resp1.json()["sid"]
 
+            smtp_server = self._require_smtp_server()
             await asyncio.sleep(0.5)
-            emails_after_first = len(self.smtp_server.received_emails)
+            emails_after_first = len(smtp_server.received_emails)
 
             # Higher send_attempt should re-send
             resp2 = requests.post(ENDPOINT, json={**base_payload, "send_attempt": 2})
@@ -784,7 +791,7 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             # Should have sent an additional email
             await asyncio.sleep(1)
             self.assertGreater(
-                len(self.smtp_server.received_emails),
+                len(smtp_server.received_emails),
                 emails_after_first,
                 "Expected a new email for higher send_attempt",
             )
@@ -883,7 +890,8 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
                 admin=True,
             )
 
-            emails_before = len(self.smtp_server.received_emails)
+            smtp_server = self._require_smtp_server()
+            emails_before = len(smtp_server.received_emails)
 
             response = requests.post(
                 ENDPOINT,
@@ -901,7 +909,7 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             # Verify no email was sent
             await asyncio.sleep(1)
             self.assertEqual(
-                len(self.smtp_server.received_emails),
+                len(smtp_server.received_emails),
                 emails_before,
                 "No email should be sent when username is already taken",
             )
@@ -961,7 +969,8 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
                 stderr_thread,
             ) = await self._start_synapse_with_email()
 
-            emails_before = len(self.smtp_server.received_emails)
+            smtp_server = self._require_smtp_server()
+            emails_before = len(smtp_server.received_emails)
 
             response = requests.post(
                 ENDPOINT,
@@ -979,7 +988,7 @@ class TestRegisterEmailE2EWithEmailConfig(BaseSynapseE2ETest):
             # Verify no email was sent for invalid usernames.
             await asyncio.sleep(1)
             self.assertEqual(
-                len(self.smtp_server.received_emails),
+                len(smtp_server.received_emails),
                 emails_before,
                 "No email should be sent when username is invalid",
             )


### PR DESCRIPTION
## What

Pin Synapse to `1.124.0` and restore module/test compatibility on that version.

## Why

Closes #60

## Testing

- `tox -e py`
- `tox -e check_codestyle`
- `tox -e check_types`

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None