### PR TITLE
feat(direct_push): implement direct push endpoint for immediate notification delivery

### DIFF
--- a/.workspace/2026-03-31/direct-push-endpoint-plan.md
+++ b/.workspace/2026-03-31/direct-push-endpoint-plan.md
@@ -1,0 +1,244 @@
+# Plan: Direct Push Endpoint on Synapse Module
+
+- Date: 2026-03-31
+- Repo: `synapse-pangea-chat-modules`
+- Scope decided here:
+  - Add an admin-only HTTP endpoint in the Synapse module for immediate push delivery without creating any Matrix event.
+  - Treat this as a Synapse-module and Sygnal delivery design, with only a short client-implications section.
+  - Assume the endpoint will authenticate using a Synapse admin access token.
+  - Assume production support is required, not staging-only.
+  - Prefer a design that is robust to dedicated pusher workers in production.
+
+## Summary
+
+The existing event-driven bot notification path is not a good fit for the new goal.
+
+- The bot currently sends a real `p.room.notice` event and relies on client push rules to notify.
+- That path also performs translation and tokenization work before the event send, which adds latency unrelated to actual push delivery.
+- The new requirement is lower-level and simpler: send a push immediately, over HTTP, with no backing Matrix event.
+
+Synapse exposes two viable implementation directions:
+
+1. Use `ModuleApi.send_http_push_notification(...)`.
+2. Read the user's registered HTTP pushers from Synapse storage and POST the same payload shape directly to each pusher's registered push gateway URL.
+
+The first option is thinner but depends on in-memory pushers on the current process. Because production runs dedicated pusher workers, that creates avoidable topology risk. The second option is slightly more custom but works against the persisted pusher registrations and is the safer default for production.
+
+## Desired Outcome
+
+- A new admin-only endpoint exists on the Synapse module.
+- Callers can trigger immediate push delivery to one user, with optional device scoping.
+- The endpoint does not create Matrix events or rely on push-rule evaluation.
+- The endpoint is resilient to Synapse worker topology differences between staging and production.
+- The response clearly reports per-device delivery attempt results.
+
+## Recommended Approach
+
+Implement a new Synapse-module endpoint that:
+
+- Authenticates the request with `ModuleApi.get_user_by_req(...)`.
+- Verifies the requester is a server admin with `ModuleApi.is_user_admin(...)`.
+- Loads the target user's registered HTTP pushers from Synapse storage.
+- Filters to enabled HTTP pushers, optionally by `device_id`.
+- Builds the same `notification.devices[0]` payload shape used by Synapse's `HttpPusher.dispatch_push(...)`.
+- POSTs that payload directly to each pusher's registered push gateway URL.
+- Returns per-device status, plus any rejected pushkeys or transport errors.
+
+This keeps the endpoint aligned with Synapse's existing push payload contract while avoiding dependence on where active pusher objects live in memory.
+
+## Proposed Endpoint Contract
+
+### Route
+
+`POST /_synapse/client/pangea/v1/send_push`
+
+### Auth
+
+- Matrix access token required.
+- Requester must be a Synapse server admin.
+- Non-admin callers get `403`.
+
+### Request Shape
+
+Proposed default schema:
+
+```json
+{
+  "user_id": "@alice:pangea.chat",
+  "device_id": "ABC123",
+  "room_id": "!room:pangea.chat",
+  "event_id": "push-20260331-abc123",
+  "body": "Your practice partner is waiting.",
+  "title": "Pangea Chat",
+  "type": "pangea.direct_push",
+  "content": {
+    "check_in_type": "default",
+    "pangea.activity.session_room_id": "!session:pangea.chat",
+    "pangea.activity.id": "activity-123"
+  },
+  "counts": {
+    "unread": 1
+  },
+  "prio": "high"
+}
+```
+
+### Notes on Fields
+
+- `user_id`: required.
+- `device_id`: optional. If omitted, fan out to all enabled HTTP pushers for that user.
+- `room_id`: recommended required field so notification taps still have a routing target.
+- `event_id`: synthetic identifier, not a real Matrix event ID. This preserves compatibility with current notification-tap code paths that expect a string `event_id` in the payload.
+- `body`: required visible notification body.
+- `title`: optional visible notification title.
+- `type`: optional logical type for downstream payload consumers.
+- `content`: arbitrary extra content flattened or preserved for client consumption.
+- `counts`: optional unread-count section.
+- `prio`: optional, default `high`.
+
+### Response Shape
+
+```json
+{
+  "user_id": "@alice:pangea.chat",
+  "attempted": 2,
+  "sent": 2,
+  "failed": 0,
+  "devices": {
+    "ABC123": {
+      "sent": true,
+      "app_id": "com.talktolearn.chat.data_message",
+      "pushkey": "<redacted>",
+      "url": "https://sygnal.pangea.chat/_matrix/push/v1/notify"
+    },
+    "XYZ999": {
+      "sent": true,
+      "app_id": "com.talktolearn.chat",
+      "pushkey": "<redacted>",
+      "url": "https://sygnal.pangea.chat/_matrix/push/v1/notify"
+    }
+  },
+  "errors": []
+}
+```
+
+## Why Not Use `ModuleApi.send_http_push_notification(...)`
+
+It is a real option and is suitable for a simpler staging-only or single-process pusher setup.
+
+However:
+
+- It iterates active in-memory HTTP pushers on the current process.
+- Staging runs pushers on the main process, so it likely works there.
+- Production uses a dedicated pusher worker, so the main-process module endpoint may not see the relevant pusher objects.
+
+Unless the endpoint is explicitly hosted where the pusher workers live, or additional replication is introduced, the storage-driven direct POST design is the safer production plan.
+
+## Checklist
+
+### 1. Confirm payload and targeting contract
+
+- [ ] Confirm whether `device_id` remains optional with default fanout to all devices.
+- [ ] Confirm whether `room_id` should be required.
+- [ ] Confirm whether the endpoint should require a caller-provided synthetic `event_id` or generate one server-side.
+- [ ] Confirm whether arbitrary extra payload should live under `content` only, or whether raw custom top-level fields are allowed.
+- [ ] Confirm whether unread counts are caller-controlled or omitted entirely.
+
+### 2. Add the module endpoint
+
+- [ ] Add a new resource class, likely under a new subpackage such as `synapse_pangea_chat/direct_push/`.
+- [ ] Register the route from `synapse_pangea_chat/__init__.py`.
+- [ ] Reuse the existing resource style used by `invite_by_email`, `delete_room`, and `user_activity`.
+- [ ] Authenticate with `ModuleApi.get_user_by_req(...)`.
+- [ ] Reject non-admin callers using `ModuleApi.is_user_admin(...)`.
+
+### 3. Implement storage-driven pusher fanout
+
+- [ ] Read the target user's pushers from Synapse storage.
+- [ ] Filter to enabled `kind == "http"` pushers only.
+- [ ] Optionally filter by `device_id` if provided.
+- [ ] Ignore non-HTTP pushers entirely.
+- [ ] Build per-pusher `devices` payload entries with the pusher's `app_id`, `pushkey`, `pushkey_ts`, and `data`.
+- [ ] Preserve pusher `data` fields such as the client's `data_message` settings.
+- [ ] POST the payload to the pusher's registered URL using Synapse's HTTP client.
+
+### 4. Define error handling and response semantics
+
+- [ ] Return `404` if the target user does not exist.
+- [ ] Return `404` or `200` with zero attempts if the user has no enabled HTTP pushers. Decide explicitly.
+- [ ] Return per-device success and failure status.
+- [ ] Redact or partially redact pushkeys in the response.
+- [ ] Log failures with enough context for debugging while avoiding leaking raw pushkeys unnecessarily.
+- [ ] Capture transport or gateway errors to Sentry.
+
+### 5. Validate client compatibility assumptions
+
+- [ ] Confirm the client can handle a synthetic `event_id` in the notification payload.
+- [ ] Confirm notification taps still route correctly when there is no backing Matrix event.
+- [ ] Confirm `p.room.notice.opened` behavior is either intentionally skipped or updated for the no-event flow.
+- [ ] Decide whether this endpoint should be used only for pushes that do not need opened-event analytics.
+
+### 6. Testing
+
+- [ ] Add unit or integration tests for admin auth.
+- [ ] Add tests for fanout to all devices.
+- [ ] Add tests for single-device targeting.
+- [ ] Add tests for users with no pushers.
+- [ ] Add tests for mixed pushers where only HTTP pushers are used.
+- [ ] Add tests for gateway error handling and partial failures.
+- [ ] If feasible, add a local integration test using a fake push endpoint instead of real Sygnal.
+
+### 7. Staging validation
+
+- [ ] Deploy to staging.
+- [ ] Use an admin access token to call the endpoint against a known user/device with active pushers.
+- [ ] Verify notification arrives without any Matrix room event being created.
+- [ ] Verify multi-device fanout behavior if the test user has multiple pushers.
+- [ ] Verify failure behavior for a user with no pushers.
+
+### 8. Production rollout
+
+- [ ] Confirm the route and auth model are acceptable for production use.
+- [ ] Confirm whether any operational rate limit is needed for admin callers.
+- [ ] Deploy module update to staging first, then production.
+- [ ] Smoke-test with one internal account before broader use.
+
+## Code Touchpoints
+
+- `synapse_pangea_chat/__init__.py`
+  - Register the new endpoint.
+- `synapse_pangea_chat/config.py`
+  - Add any config values if rate limits or payload constraints become configurable.
+- New module files, likely under `synapse_pangea_chat/direct_push/`
+  - Request parsing.
+  - Admin auth.
+  - Pusher lookup and fanout.
+  - Payload construction.
+- `tests/`
+  - Endpoint-level tests.
+
+## Client Implications
+
+The endpoint intentionally breaks the old assumption that every push corresponds to a real Matrix event.
+
+That means:
+
+- notification tap behavior must tolerate synthetic `event_id` values,
+- opened-event analytics may need to be skipped or redesigned for this flow,
+- any feature that tries to fetch the notification event by ID will not work unless the client is adjusted not to rely on that.
+
+This plan assumes that contract change is acceptable.
+
+## Open Decisions To Resolve During Implementation
+
+- [ ] Whether `event_id` is required from the caller or generated by the module.
+- [ ] Whether `room_id` is required or merely recommended.
+- [ ] Whether the endpoint response should expose the destination Sygnal URL per device or keep that internal.
+- [ ] Whether users with no active HTTP pushers should be treated as `404`, `409`, or `200` with zero attempts.
+- [ ] Whether to add explicit rate limiting even for admin-only access.
+
+## Notes
+
+- The production-safe default is storage-driven fanout, not in-memory pusher fanout.
+- The endpoint should stay intentionally narrow: admin-only, HTTP push only, no attempt to emulate full Matrix event semantics.
+- If later needed, a second endpoint can be added for a richer payload builder once real call sites settle.

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -7,6 +7,7 @@ from synapse.module_api import ModuleApi
 from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.delete_room import DeleteRoom
 from synapse_pangea_chat.delete_user import DeleteUser
+from synapse_pangea_chat.direct_push import DirectPush
 from synapse_pangea_chat.email_invite import CreateCourseSpace, InviteByEmail
 from synapse_pangea_chat.export_user_data import ExportUserData
 from synapse_pangea_chat.limit_user_directory import LimitUserDirectory
@@ -140,6 +141,13 @@ class PangeaChat:
         self._api.register_web_resource(
             path="/_synapse/client/pangea/v1/register/email/requestToken",
             resource=self.register_email_resource,
+        )
+
+        # --- Direct Push ---
+        self.direct_push_resource = DirectPush(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/send_push",
+            resource=self.direct_push_resource,
         )
 
         # --- Limit User Directory ---

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -369,9 +369,18 @@ class PangeaChat:
         invite_by_email_burst_duration_seconds = config.get(
             "invite_by_email_burst_duration_seconds", 60
         )
-        app_base_url = config.get(
-            "app_base_url", "https://app.pangea.chat"
+        app_base_url = config.get("app_base_url", "https://app.pangea.chat")
+
+        # --- send_push config ---
+        send_push_requests_per_burst = config.get("send_push_requests_per_burst", 10)
+        if send_push_requests_per_burst < 1:
+            raise ValueError("send_push_requests_per_burst must be >= 1")
+
+        send_push_burst_duration_seconds = config.get(
+            "send_push_burst_duration_seconds", 1
         )
+        if send_push_burst_duration_seconds < 1:
+            raise ValueError("send_push_burst_duration_seconds must be >= 1")
 
         return PangeaChatConfig(
             public_courses_burst_duration_seconds=public_courses_burst_duration_seconds,
@@ -407,4 +416,6 @@ class PangeaChat:
             invite_by_email_requests_per_burst=invite_by_email_requests_per_burst,
             invite_by_email_burst_duration_seconds=invite_by_email_burst_duration_seconds,
             app_base_url=app_base_url,
+            send_push_requests_per_burst=send_push_requests_per_burst,
+            send_push_burst_duration_seconds=send_push_burst_duration_seconds,
         )

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -80,3 +80,7 @@ class PangeaChatConfig:
     invite_by_email_requests_per_burst: int = 5
     invite_by_email_burst_duration_seconds: int = 60
     app_base_url: str = "https://app.pangea.chat"
+
+    # --- send_push config ---
+    send_push_requests_per_burst: int = 10
+    send_push_burst_duration_seconds: int = 1

--- a/synapse_pangea_chat/direct_push/__init__.py
+++ b/synapse_pangea_chat/direct_push/__init__.py
@@ -1,0 +1,3 @@
+from synapse_pangea_chat.direct_push.direct_push import DirectPush
+
+__all__ = ["DirectPush"]

--- a/synapse_pangea_chat/direct_push/direct_push.py
+++ b/synapse_pangea_chat/direct_push/direct_push.py
@@ -7,7 +7,11 @@ import time
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from synapse.api.errors import AuthError, SynapseError
+from synapse.api.errors import (
+    AuthError,
+    InvalidClientTokenError,
+    MissingClientTokenError,
+)
 from synapse.http import server
 from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
@@ -18,7 +22,11 @@ from twisted.web.http_headers import Headers
 from twisted.web.resource import Resource
 
 from synapse_pangea_chat.direct_push.is_rate_limited import is_rate_limited
-from synapse_pangea_chat.direct_push.types import DeviceStatus, SendPushRequest, SendPushResponse
+from synapse_pangea_chat.direct_push.types import (
+    DeviceStatus,
+    SendPushRequest,
+    SendPushResponse,
+)
 
 if TYPE_CHECKING:
     from synapse_pangea_chat.config import PangeaChatConfig
@@ -46,54 +54,84 @@ class DirectPush(Resource):
             requester_id = requester.user.to_string()
 
             if not await self._api.is_user_admin(requester_id):
-                respond_with_json(request, 403, {"error": "Admin access required"}, send_cors=True)
+                respond_with_json(
+                    request, 403, {"error": "Admin access required"}, send_cors=True
+                )
                 return
 
             if is_rate_limited(requester_id, self._config):
-                respond_with_json(request, 429, {"error": "Rate limited"}, send_cors=True)
+                respond_with_json(
+                    request, 429, {"error": "Rate limited"}, send_cors=True
+                )
                 return
 
             body = await self._extract_body_json(request)
             if body is None:
-                respond_with_json(request, 400, {"error": "Invalid JSON"}, send_cors=True)
+                respond_with_json(
+                    request, 400, {"error": "Invalid JSON"}, send_cors=True
+                )
                 return
 
             target_user_id = body.get("user_id")
             if not target_user_id:
-                respond_with_json(request, 400, {"error": "Missing user_id"}, send_cors=True)
+                respond_with_json(
+                    request, 400, {"error": "Missing user_id"}, send_cors=True
+                )
                 return
 
             device_id = body.get("device_id")
             room_id = body.get("room_id")
             if not room_id:
-                respond_with_json(request, 400, {"error": "Missing room_id"}, send_cors=True)
+                respond_with_json(
+                    request, 400, {"error": "Missing room_id"}, send_cors=True
+                )
                 return
 
             body_text = body.get("body")
             if not body_text:
-                respond_with_json(request, 400, {"error": "Missing body"}, send_cors=True)
+                respond_with_json(
+                    request, 400, {"error": "Missing body"}, send_cors=True
+                )
                 return
 
             response = await self._send_push(target_user_id, device_id, body)
             respond_with_json(request, 200, response, send_cors=True)
 
-        except AuthError as e:
-            respond_with_json(request, 401, {"error": str(e)}, send_cors=True)
-        except Exception as e:
+        except (AuthError, InvalidClientTokenError, MissingClientTokenError) as e:
+            logger.info("Authentication failed: %s", e)
+            respond_with_json(
+                request,
+                401,
+                {"error": "Unauthorized", "errcode": "M_UNAUTHORIZED"},
+                send_cors=True,
+            )
+        except Exception:  # noqa: BLE001
             logger.exception("Error in direct_push endpoint")
-            respond_with_json(request, 500, {"error": "Internal server error"}, send_cors=True)
+            respond_with_json(
+                request, 500, {"error": "Internal server error"}, send_cors=True
+            )
 
-    async def _extract_body_json(self, request: SynapseRequest) -> Optional[Dict[str, Any]]:
+    async def _extract_body_json(
+        self, request: SynapseRequest
+    ) -> Optional[SendPushRequest]:
         try:
             content = request.content.read()
             if not content:
                 return {}
-            return json.loads(content)
+            parsed = json.loads(content)
         except (json.JSONDecodeError, ValueError):
             return None
 
+        if not isinstance(parsed, dict):
+            return None
+
+        return parsed
+
     async def _send_push(
-        self, target_user_id: str, device_id: Optional[str], req_body: Dict[str, Any]
+        self,
+        target_user_id: str,
+        device_id: Optional[str],
+        req_body: SendPushRequest,
     ) -> SendPushResponse:
         pushers = await self._get_pushers(target_user_id, device_id)
 
@@ -109,15 +147,22 @@ class DirectPush(Resource):
         if not pushers:
             return response
 
-        event_id = req_body.get("event_id") or f"push-{int(time.time())}-{secrets.token_hex(6)}"
+        event_id = (
+            req_body.get("event_id")
+            or f"push-{int(time.time())}-{secrets.token_hex(6)}"
+        )
 
         for pusher in pushers:
             device_id_key = pusher.get("device_id", "unknown")
-            status: DeviceStatus = {"sent": False, "app_id": pusher.get("app_id", ""), "pushkey": ""}
+            status: DeviceStatus = {
+                "sent": False,
+                "app_id": pusher.get("app_id", ""),
+                "pushkey": pusher.get("pushkey", ""),
+            }
 
             try:
-                payload = self._build_payload(target_user_id, event_id, req_body, pusher)
-                success = await self._post_to_sygnal(pusher["pushkey"], payload)
+                payload = self._build_payload(event_id, req_body, pusher)
+                success = await self._post_to_sygnal(payload)
 
                 if success:
                     status["sent"] = True
@@ -125,11 +170,13 @@ class DirectPush(Resource):
                 else:
                     response["failed"] += 1
                     status["error"] = "Sygnal returned error"
+                    response["errors"].append(f"{device_id_key}: {status['error']}")
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 response["failed"] += 1
                 status["error"] = str(e)
-                logger.exception(f"Error posting to Sygnal for {device_id_key}")
+                response["errors"].append(f"{device_id_key}: {status['error']}")
+                logger.exception("Error posting to Sygnal for %s", device_id_key)
 
             response["devices"][device_id_key] = status
 
@@ -138,30 +185,29 @@ class DirectPush(Resource):
     async def _get_pushers(
         self, user_id: str, device_id: Optional[str]
     ) -> list[Dict[str, Any]]:
-        try:
-            pushers_iter = await self._datastores.main.get_pushers_by_user_id(user_id)
-            pushers = []
-            async for pusher in pushers_iter:
-                if not pusher.enabled:
-                    continue
-                if device_id and pusher.device_id != device_id:
-                    continue
-                pushers.append(
-                    {
-                        "device_id": pusher.device_id,
-                        "app_id": pusher.app_id,
-                        "pushkey": pusher.pushkey,
-                        "pushkey_ts": pusher.pushkey_ts,
-                        "data": pusher.data,
-                    }
-                )
-            return pushers
-        except Exception as e:
-            logger.exception(f"Error fetching pushers for {user_id}")
-            return []
+        pushers_iter = await self._datastores.main.get_pushers_by_user_id(user_id)
+        pushers = []
+        for pusher in pushers_iter:
+            if not pusher.enabled:
+                continue
+            if device_id and pusher.device_id != device_id:
+                continue
+            pushers.append(
+                {
+                    "device_id": pusher.device_id,
+                    "app_id": pusher.app_id,
+                    "pushkey": pusher.pushkey,
+                    "pushkey_ts": pusher.pushkey_ts,
+                    "data": pusher.data,
+                }
+            )
+        return pushers
 
     def _build_payload(
-        self, user_id: str, event_id: str, req_body: Dict[str, Any], pusher: Dict[str, Any]
+        self,
+        event_id: str,
+        req_body: SendPushRequest,
+        pusher: Dict[str, Any],
     ) -> Dict[str, Any]:
         return {
             "notification": {
@@ -191,7 +237,7 @@ class DirectPush(Resource):
             }
         }
 
-    async def _post_to_sygnal(self, pushkey: str, payload: Dict[str, Any]) -> bool:
+    async def _post_to_sygnal(self, payload: Dict[str, Any]) -> bool:
         try:
             agent = Agent(reactor)
             url = b"https://sygnal.pangea.chat/_matrix/push/v1/notify"
@@ -209,10 +255,10 @@ class DirectPush(Resource):
             await readBody(response)
 
             if response.code >= 400:
-                logger.warning(f"Sygnal returned {response.code}")
+                logger.warning("Sygnal returned %s", response.code)
                 return False
 
             return True
-        except Exception as e:
-            logger.exception(f"Error posting to Sygnal: {e}")
+        except Exception:  # noqa: BLE001
+            logger.exception("Error posting to Sygnal")
             return False

--- a/synapse_pangea_chat/direct_push/direct_push.py
+++ b/synapse_pangea_chat/direct_push/direct_push.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from io import BytesIO
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from synapse.api.errors import AuthError, SynapseError
+from synapse.http import server
+from synapse.http.server import respond_with_json
+from synapse.http.site import SynapseRequest
+from synapse.module_api import ModuleApi
+from twisted.internet import defer, reactor
+from twisted.web.client import Agent, FileBodyProducer, readBody
+from twisted.web.http_headers import Headers
+from twisted.web.resource import Resource
+
+from synapse_pangea_chat.direct_push.is_rate_limited import is_rate_limited
+from synapse_pangea_chat.direct_push.types import DeviceStatus, SendPushRequest, SendPushResponse
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger("synapse.module.synapse_pangea_chat.direct_push")
+
+
+class DirectPush(Resource):
+    isLeaf = True
+
+    def __init__(self, api: ModuleApi, config: PangeaChatConfig):
+        super().__init__()
+        self._api = api
+        self._config = config
+        self._auth = self._api._hs.get_auth()
+        self._datastores = self._api._hs.get_datastores()
+
+    def render_POST(self, request: SynapseRequest):
+        defer.ensureDeferred(self._async_render_POST(request))
+        return server.NOT_DONE_YET
+
+    async def _async_render_POST(self, request: SynapseRequest):
+        try:
+            requester = await self._auth.get_user_by_req(request)
+            requester_id = requester.user.to_string()
+
+            if not await self._api.is_user_admin(requester_id):
+                respond_with_json(request, 403, {"error": "Admin access required"}, send_cors=True)
+                return
+
+            if is_rate_limited(requester_id, self._config):
+                respond_with_json(request, 429, {"error": "Rate limited"}, send_cors=True)
+                return
+
+            body = await self._extract_body_json(request)
+            if body is None:
+                respond_with_json(request, 400, {"error": "Invalid JSON"}, send_cors=True)
+                return
+
+            target_user_id = body.get("user_id")
+            if not target_user_id:
+                respond_with_json(request, 400, {"error": "Missing user_id"}, send_cors=True)
+                return
+
+            device_id = body.get("device_id")
+            room_id = body.get("room_id")
+            if not room_id:
+                respond_with_json(request, 400, {"error": "Missing room_id"}, send_cors=True)
+                return
+
+            body_text = body.get("body")
+            if not body_text:
+                respond_with_json(request, 400, {"error": "Missing body"}, send_cors=True)
+                return
+
+            response = await self._send_push(target_user_id, device_id, body)
+            respond_with_json(request, 200, response, send_cors=True)
+
+        except AuthError as e:
+            respond_with_json(request, 401, {"error": str(e)}, send_cors=True)
+        except Exception as e:
+            logger.exception("Error in direct_push endpoint")
+            respond_with_json(request, 500, {"error": "Internal server error"}, send_cors=True)
+
+    async def _extract_body_json(self, request: SynapseRequest) -> Optional[Dict[str, Any]]:
+        try:
+            content = request.content.read()
+            if not content:
+                return {}
+            return json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    async def _send_push(
+        self, target_user_id: str, device_id: Optional[str], req_body: Dict[str, Any]
+    ) -> SendPushResponse:
+        pushers = await self._get_pushers(target_user_id, device_id)
+
+        response: SendPushResponse = {
+            "user_id": target_user_id,
+            "attempted": len(pushers),
+            "sent": 0,
+            "failed": 0,
+            "devices": {},
+            "errors": [],
+        }
+
+        if not pushers:
+            return response
+
+        event_id = req_body.get("event_id") or f"push-{int(time.time())}-{secrets.token_hex(6)}"
+
+        for pusher in pushers:
+            device_id_key = pusher.get("device_id", "unknown")
+            status: DeviceStatus = {"sent": False, "app_id": pusher.get("app_id", ""), "pushkey": ""}
+
+            try:
+                payload = self._build_payload(target_user_id, event_id, req_body, pusher)
+                success = await self._post_to_sygnal(pusher["pushkey"], payload)
+
+                if success:
+                    status["sent"] = True
+                    response["sent"] += 1
+                else:
+                    response["failed"] += 1
+                    status["error"] = "Sygnal returned error"
+
+            except Exception as e:
+                response["failed"] += 1
+                status["error"] = str(e)
+                logger.exception(f"Error posting to Sygnal for {device_id_key}")
+
+            response["devices"][device_id_key] = status
+
+        return response
+
+    async def _get_pushers(
+        self, user_id: str, device_id: Optional[str]
+    ) -> list[Dict[str, Any]]:
+        try:
+            pushers_iter = await self._datastores.main.get_pushers_by_user_id(user_id)
+            pushers = []
+            async for pusher in pushers_iter:
+                if not pusher.enabled:
+                    continue
+                if device_id and pusher.device_id != device_id:
+                    continue
+                pushers.append(
+                    {
+                        "device_id": pusher.device_id,
+                        "app_id": pusher.app_id,
+                        "pushkey": pusher.pushkey,
+                        "pushkey_ts": pusher.pushkey_ts,
+                        "data": pusher.data,
+                    }
+                )
+            return pushers
+        except Exception as e:
+            logger.exception(f"Error fetching pushers for {user_id}")
+            return []
+
+    def _build_payload(
+        self, user_id: str, event_id: str, req_body: Dict[str, Any], pusher: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {
+            "notification": {
+                "event_id": event_id,
+                "room_id": req_body.get("room_id"),
+                "type": req_body.get("type", "m.room.message"),
+                "sender": "@bot:pangea.chat",
+                "sender_display_name": "Pangea Bot",
+                "room_name": "",
+                "room_avatar_url": None,
+                "prio": req_body.get("prio", "high"),
+                "content": {
+                    "msgtype": "m.text",
+                    "body": req_body.get("body"),
+                    **(req_body.get("content") or {}),
+                },
+                "counts": {"unread": 1, "missed_calls": 0},
+                "devices": [
+                    {
+                        "app_id": pusher["app_id"],
+                        "pushkey": pusher["pushkey"],
+                        "pushkey_ts": pusher["pushkey_ts"],
+                        "data": pusher["data"],
+                        "tweaks": {},
+                    }
+                ],
+            }
+        }
+
+    async def _post_to_sygnal(self, pushkey: str, payload: Dict[str, Any]) -> bool:
+        try:
+            agent = Agent(reactor)
+            url = b"https://sygnal.pangea.chat/_matrix/push/v1/notify"
+            body_bytes = json.dumps(payload).encode("utf-8")
+
+            producer = FileBodyProducer(BytesIO(body_bytes))
+
+            response = await agent.request(
+                b"POST",
+                url,
+                Headers({b"Content-Type": [b"application/json"]}),
+                producer,
+            )
+
+            await readBody(response)
+
+            if response.code >= 400:
+                logger.warning(f"Sygnal returned {response.code}")
+                return False
+
+            return True
+        except Exception as e:
+            logger.exception(f"Error posting to Sygnal: {e}")
+            return False

--- a/synapse_pangea_chat/direct_push/is_rate_limited.py
+++ b/synapse_pangea_chat/direct_push/is_rate_limited.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Dict, List
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+request_log: Dict[str, List[float]] = {}
+
+
+def is_rate_limited(user_id: str, config: PangeaChatConfig) -> bool:
+    current_time = time.time()
+
+    if user_id not in request_log:
+        request_log[user_id] = []
+
+    request_log[user_id] = [
+        timestamp
+        for timestamp in request_log[user_id]
+        if current_time - timestamp <= config.send_push_burst_duration_seconds
+    ]
+
+    if len(request_log[user_id]) >= config.send_push_requests_per_burst:
+        return True
+
+    request_log[user_id].append(current_time)
+
+    return False

--- a/synapse_pangea_chat/direct_push/types.py
+++ b/synapse_pangea_chat/direct_push/types.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, TypedDict
+
+
+class SendPushRequest(TypedDict, total=False):
+    user_id: str
+    device_id: Optional[str]
+    room_id: str
+    event_id: str
+    body: str
+    title: Optional[str]
+    type: Optional[str]
+    content: Optional[Dict[str, Any]]
+    prio: Optional[str]
+
+
+class DeviceStatus(TypedDict, total=False):
+    sent: bool
+    app_id: str
+    pushkey: str
+    error: Optional[str]
+    status_code: Optional[int]
+
+
+class SendPushResponse(TypedDict):
+    user_id: str
+    attempted: int
+    sent: int
+    failed: int
+    devices: Dict[str, DeviceStatus]
+    errors: list[str]

--- a/tests/test_direct_push_e2e.py
+++ b/tests/test_direct_push_e2e.py
@@ -1,24 +1,45 @@
 import requests
 
+from synapse_pangea_chat.direct_push.is_rate_limited import request_log
+
 from .base_e2e import BaseSynapseE2ETest
 
 
 class TestDirectPushE2E(BaseSynapseE2ETest):
     """E2E tests for direct push endpoint."""
 
+    def setUp(self):
+        super().setUp()
+        request_log.clear()
+
+    def tearDown(self):
+        request_log.clear()
+        super().tearDown()
+
     async def test_send_push_admin_only(self):
         """Non-admin users get 403."""
-        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
-            await self.start_test_synapse()
-        )
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
 
         try:
-            await self.register_user(config_path, synapse_dir, "alice", "pw", admin=False)
+            await self.register_user(
+                config_path, synapse_dir, "alice", "pw", admin=False
+            )
             _, token = await self.login_user("alice", "pw")
 
             response = requests.post(
                 f"{self.server_url}/_synapse/client/pangea/v1/send_push",
-                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Test"},
+                json={
+                    "user_id": "@alice:my.domain.name",
+                    "room_id": "!room:test",
+                    "body": "Test",
+                },
                 headers={"Authorization": f"Bearer {token}"},
             )
 
@@ -34,12 +55,19 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
 
     async def test_send_push_missing_room_id(self):
         """Missing room_id returns 400."""
-        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
-            await self.start_test_synapse()
-        )
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
 
         try:
-            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            await self.register_user(
+                config_path, synapse_dir, "admin", "pw", admin=True
+            )
             _, admin_token = await self.login_user("admin", "pw")
 
             response = requests.post(
@@ -60,18 +88,31 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
 
     async def test_send_push_no_pushers(self):
         """User with no pushers returns 200 with attempted: 0."""
-        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
-            await self.start_test_synapse()
-        )
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
 
         try:
-            await self.register_user(config_path, synapse_dir, "alice", "pw", admin=False)
-            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            await self.register_user(
+                config_path, synapse_dir, "alice", "pw", admin=False
+            )
+            await self.register_user(
+                config_path, synapse_dir, "admin", "pw", admin=True
+            )
             _, admin_token = await self.login_user("admin", "pw")
 
             response = requests.post(
                 f"{self.server_url}/_synapse/client/pangea/v1/send_push",
-                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Test"},
+                json={
+                    "user_id": "@alice:my.domain.name",
+                    "room_id": "!room:test",
+                    "body": "Test",
+                },
                 headers={"Authorization": f"Bearer {admin_token}"},
             )
 
@@ -90,25 +131,40 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
 
     async def test_send_push_rate_limit(self):
         """Admin users are rate limited after 10 requests."""
-        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
-            await self.start_test_synapse()
-        )
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
 
         try:
-            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            await self.register_user(
+                config_path, synapse_dir, "admin", "pw", admin=True
+            )
             _, admin_token = await self.login_user("admin", "pw")
 
             for i in range(10):
                 response = requests.post(
                     f"{self.server_url}/_synapse/client/pangea/v1/send_push",
-                    json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": f"Test {i}"},
+                    json={
+                        "user_id": "@alice:my.domain.name",
+                        "room_id": "!room:test",
+                        "body": f"Test {i}",
+                    },
                     headers={"Authorization": f"Bearer {admin_token}"},
                 )
                 self.assertEqual(response.status_code, 200)
 
             response = requests.post(
                 f"{self.server_url}/_synapse/client/pangea/v1/send_push",
-                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Rate limited"},
+                json={
+                    "user_id": "@alice:my.domain.name",
+                    "room_id": "!room:test",
+                    "body": "Rate limited",
+                },
                 headers={"Authorization": f"Bearer {admin_token}"},
             )
 

--- a/tests/test_direct_push_e2e.py
+++ b/tests/test_direct_push_e2e.py
@@ -1,0 +1,123 @@
+import requests
+
+from .base_e2e import BaseSynapseE2ETest
+
+
+class TestDirectPushE2E(BaseSynapseE2ETest):
+    """E2E tests for direct push endpoint."""
+
+    async def test_send_push_admin_only(self):
+        """Non-admin users get 403."""
+        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
+            await self.start_test_synapse()
+        )
+
+        try:
+            await self.register_user(config_path, synapse_dir, "alice", "pw", admin=False)
+            _, token = await self.login_user("alice", "pw")
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Test"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+            self.assertEqual(response.status_code, 403)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_send_push_missing_room_id(self):
+        """Missing room_id returns 400."""
+        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
+            await self.start_test_synapse()
+        )
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            _, admin_token = await self.login_user("admin", "pw")
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={"user_id": "@alice:my.domain.name", "body": "Test"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 400)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_send_push_no_pushers(self):
+        """User with no pushers returns 200 with attempted: 0."""
+        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
+            await self.start_test_synapse()
+        )
+
+        try:
+            await self.register_user(config_path, synapse_dir, "alice", "pw", admin=False)
+            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            _, admin_token = await self.login_user("admin", "pw")
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Test"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["attempted"], 0)
+            self.assertEqual(data["sent"], 0)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_send_push_rate_limit(self):
+        """Admin users are rate limited after 10 requests."""
+        postgres, synapse_dir, config_path, server_process, stdout_thread, stderr_thread = (
+            await self.start_test_synapse()
+        )
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", admin=True)
+            _, admin_token = await self.login_user("admin", "pw")
+
+            for i in range(10):
+                response = requests.post(
+                    f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                    json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": f"Test {i}"},
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                )
+                self.assertEqual(response.status_code, 200)
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={"user_id": "@alice:my.domain.name", "room_id": "!room:test", "body": "Rate limited"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 429)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )

--- a/tests/test_direct_push_unit.py
+++ b/tests/test_direct_push_unit.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import unittest
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from synapse_pangea_chat import PangeaChat
+from synapse_pangea_chat.direct_push.direct_push import DirectPush
+
+
+def _make_handler() -> DirectPush:
+    api = MagicMock()
+    api._hs.get_auth.return_value = MagicMock()
+    api._hs.get_datastores.return_value = MagicMock()
+    return DirectPush(api, MagicMock())
+
+
+def _iter(items):
+    return iter(items)
+
+
+class TestDirectPushConfig(unittest.TestCase):
+    def test_parse_config_includes_send_push_overrides(self):
+        config = PangeaChat.parse_config(
+            {
+                "cms_base_url": "http://cms.example.test",
+                "cms_service_api_key": "test-api-key",
+                "send_push_requests_per_burst": 25,
+                "send_push_burst_duration_seconds": 7,
+            }
+        )
+
+        self.assertEqual(config.send_push_requests_per_burst, 25)
+        self.assertEqual(config.send_push_burst_duration_seconds, 7)
+
+    def test_parse_config_rejects_invalid_send_push_values(self):
+        with self.assertRaisesRegex(ValueError, "send_push_requests_per_burst"):
+            PangeaChat.parse_config(
+                {
+                    "cms_base_url": "http://cms.example.test",
+                    "cms_service_api_key": "test-api-key",
+                    "send_push_requests_per_burst": 0,
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "send_push_burst_duration_seconds"):
+            PangeaChat.parse_config(
+                {
+                    "cms_base_url": "http://cms.example.test",
+                    "cms_service_api_key": "test-api-key",
+                    "send_push_burst_duration_seconds": 0,
+                }
+            )
+
+
+class TestDirectPushHelpers(unittest.IsolatedAsyncioTestCase):
+    async def test_extract_body_json_rejects_non_object_json(self):
+        handler = _make_handler()
+        request = SimpleNamespace(content=BytesIO(b"[]"))
+
+        self.assertIsNone(await handler._extract_body_json(request))
+
+    async def test_get_pushers_filters_disabled_and_device_id(self):
+        handler = _make_handler()
+        pushers = [
+            SimpleNamespace(
+                enabled=True,
+                device_id="device-a",
+                app_id="app",
+                pushkey="push-a",
+                pushkey_ts=1,
+                data={"brand": "ios"},
+            ),
+            SimpleNamespace(
+                enabled=False,
+                device_id="device-b",
+                app_id="app",
+                pushkey="push-b",
+                pushkey_ts=2,
+                data={"brand": "android"},
+            ),
+        ]
+        handler._datastores.main.get_pushers_by_user_id = AsyncMock(
+            return_value=_iter(pushers)
+        )
+
+        result = await handler._get_pushers("@alice:my.domain.name", "device-a")
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "device_id": "device-a",
+                    "app_id": "app",
+                    "pushkey": "push-a",
+                    "pushkey_ts": 1,
+                    "data": {"brand": "ios"},
+                }
+            ],
+        )
+
+    async def test_send_push_tracks_success_and_failures_per_device(self):
+        handler = _make_handler()
+        handler._get_pushers = AsyncMock(
+            return_value=[
+                {
+                    "device_id": "device-a",
+                    "app_id": "app-a",
+                    "pushkey": "push-a",
+                    "pushkey_ts": 1,
+                    "data": {},
+                },
+                {
+                    "device_id": "device-b",
+                    "app_id": "app-b",
+                    "pushkey": "push-b",
+                    "pushkey_ts": 2,
+                    "data": {},
+                },
+            ]
+        )
+        handler._post_to_sygnal = AsyncMock(side_effect=[True, False])
+
+        result = await handler._send_push(
+            "@alice:my.domain.name",
+            None,
+            {"room_id": "!room:test", "body": "hello"},
+        )
+
+        self.assertEqual(result["attempted"], 2)
+        self.assertEqual(result["sent"], 1)
+        self.assertEqual(result["failed"], 1)
+        self.assertTrue(result["devices"]["device-a"]["sent"])
+        self.assertEqual(result["devices"]["device-a"]["pushkey"], "push-a")
+        self.assertEqual(
+            result["devices"]["device-b"]["error"], "Sygnal returned error"
+        )
+        self.assertEqual(result["errors"], ["device-b: Sygnal returned error"])
+
+    def test_build_payload_includes_message_and_device_metadata(self):
+        handler = _make_handler()
+
+        payload = handler._build_payload(
+            "event-1",
+            {
+                "room_id": "!room:test",
+                "body": "hello",
+                "content": {"format": "org.matrix.custom.html"},
+                "type": "m.room.message",
+                "prio": "high",
+            },
+            {
+                "app_id": "app-a",
+                "pushkey": "push-a",
+                "pushkey_ts": 123,
+                "data": {"default_payload": {"aps": {}}},
+            },
+        )
+
+        self.assertEqual(payload["notification"]["event_id"], "event-1")
+        self.assertEqual(payload["notification"]["room_id"], "!room:test")
+        self.assertEqual(payload["notification"]["content"]["body"], "hello")
+        self.assertEqual(
+            payload["notification"]["content"]["format"],
+            "org.matrix.custom.html",
+        )
+        self.assertEqual(payload["notification"]["devices"][0]["pushkey"], "push-a")


### PR DESCRIPTION
## What

- Add the admin-only `/_synapse/client/pangea/v1/send_push` endpoint for direct Sygnal delivery
- Harden request validation, config parsing, and per-device error reporting
- Add unit and integration coverage for the direct push module

## Why

Closes #66

## Testing

- `python -m unittest tests.test_direct_push_unit tests.test_direct_push_e2e`
- `tox -e check_codestyle`

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None
