### PR TITLE
fix(direct_push): handle live pusher config ts fallback

### DIFF
--- a/synapse_pangea_chat/direct_push/direct_push.py
+++ b/synapse_pangea_chat/direct_push/direct_push.py
@@ -192,12 +192,13 @@ class DirectPush(Resource):
                 continue
             if device_id and pusher.device_id != device_id:
                 continue
+            pushkey_ts = getattr(pusher, "pushkey_ts", getattr(pusher, "ts", None))
             pushers.append(
                 {
                     "device_id": pusher.device_id,
                     "app_id": pusher.app_id,
                     "pushkey": pusher.pushkey,
-                    "pushkey_ts": pusher.pushkey_ts,
+                    "pushkey_ts": pushkey_ts,
                     "data": pusher.data,
                 }
             )
@@ -229,7 +230,7 @@ class DirectPush(Resource):
                     {
                         "app_id": pusher["app_id"],
                         "pushkey": pusher["pushkey"],
-                        "pushkey_ts": pusher["pushkey_ts"],
+                        "pushkey_ts": pusher.get("pushkey_ts"),
                         "data": pusher["data"],
                         "tweaks": {},
                     }

--- a/tests/test_direct_push_e2e.py
+++ b/tests/test_direct_push_e2e.py
@@ -129,6 +129,70 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
                 postgres=postgres,
             )
 
+    async def test_send_push_with_real_http_pusher_does_not_500(self):
+        """A stored HTTP pusher should not crash direct push lookup."""
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(
+                config_path, synapse_dir, "alice", "pw", admin=False
+            )
+            await self.register_user(
+                config_path, synapse_dir, "admin", "pw", admin=True
+            )
+            _, alice_token = await self.login_user("alice", "pw")
+            _, admin_token = await self.login_user("admin", "pw")
+
+            pusher_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/pushers/set",
+                json={
+                    "kind": "http",
+                    "app_id": "com.talktolearn.chat",
+                    "app_display_name": "Pangea Chat",
+                    "device_display_name": "Test iPhone",
+                    "pushkey": "pushkey-1",
+                    "lang": "en",
+                    "data": {
+                        "url": "https://sygnal.staging.pangea.chat/_matrix/push/v1/notify"
+                    },
+                },
+                headers={"Authorization": f"Bearer {alice_token}"},
+            )
+            self.assertEqual(pusher_response.status_code, 200)
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={
+                    "user_id": "@alice:my.domain.name",
+                    "room_id": "!room:test",
+                    "body": "Test",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["attempted"], 1)
+            self.assertIn("devices", data)
+            self.assertIn(
+                "pushkey-1", [device["pushkey"] for device in data["devices"].values()]
+            )
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
     async def test_send_push_rate_limit(self):
         """Admin users are rate limited after 10 requests."""
         (

--- a/tests/test_direct_push_unit.py
+++ b/tests/test_direct_push_unit.py
@@ -100,6 +100,37 @@ class TestDirectPushHelpers(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_get_pushers_falls_back_to_ts_when_pushkey_ts_missing(self):
+        handler = _make_handler()
+        pushers = [
+            SimpleNamespace(
+                enabled=True,
+                device_id="device-a",
+                app_id="app",
+                pushkey="push-a",
+                ts=99,
+                data={"brand": "ios"},
+            )
+        ]
+        handler._datastores.main.get_pushers_by_user_id = AsyncMock(
+            return_value=_iter(pushers)
+        )
+
+        result = await handler._get_pushers("@alice:my.domain.name", None)
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "device_id": "device-a",
+                    "app_id": "app",
+                    "pushkey": "push-a",
+                    "pushkey_ts": 99,
+                    "data": {"brand": "ios"},
+                }
+            ],
+        )
+
     async def test_send_push_tracks_success_and_failures_per_device(self):
         handler = _make_handler()
         handler._get_pushers = AsyncMock(
@@ -166,3 +197,21 @@ class TestDirectPushHelpers(unittest.IsolatedAsyncioTestCase):
             "org.matrix.custom.html",
         )
         self.assertEqual(payload["notification"]["devices"][0]["pushkey"], "push-a")
+
+    def test_build_payload_allows_missing_pushkey_ts(self):
+        handler = _make_handler()
+
+        payload = handler._build_payload(
+            "event-1",
+            {
+                "room_id": "!room:test",
+                "body": "hello",
+            },
+            {
+                "app_id": "app-a",
+                "pushkey": "push-a",
+                "data": {},
+            },
+        )
+
+        self.assertIsNone(payload["notification"]["devices"][0]["pushkey_ts"])


### PR DESCRIPTION
## What
- fall back to `PusherConfig.ts` when `pushkey_ts` is not present
- keep payload building tolerant of missing normalized timestamp data
- add unit and e2e regression coverage for a real stored HTTP pusher

## Why
- Closes #70

## Testing
- `python -m unittest tests.test_direct_push_unit tests.test_direct_push_e2e`
- [ ] Staging
- [ ] Production

## Deploy Notes
- None