### PR TITLE
fix(direct_push): make sygnal url configurable

### DIFF
--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -382,6 +382,13 @@ class PangeaChat:
         if send_push_burst_duration_seconds < 1:
             raise ValueError("send_push_burst_duration_seconds must be >= 1")
 
+        send_push_sygnal_url = config.get("send_push_sygnal_url")
+        if send_push_sygnal_url is not None:
+            if not isinstance(send_push_sygnal_url, str):
+                raise ValueError('Config "send_push_sygnal_url" must be a string')
+            if not send_push_sygnal_url.strip():
+                raise ValueError('Config "send_push_sygnal_url" must not be empty')
+
         return PangeaChatConfig(
             public_courses_burst_duration_seconds=public_courses_burst_duration_seconds,
             public_courses_requests_per_burst=public_courses_requests_per_burst,
@@ -418,4 +425,5 @@ class PangeaChat:
             app_base_url=app_base_url,
             send_push_requests_per_burst=send_push_requests_per_burst,
             send_push_burst_duration_seconds=send_push_burst_duration_seconds,
+            send_push_sygnal_url=send_push_sygnal_url,
         )

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -84,3 +84,4 @@ class PangeaChatConfig:
     # --- send_push config ---
     send_push_requests_per_burst: int = 10
     send_push_burst_duration_seconds: int = 1
+    send_push_sygnal_url: Optional[str] = None

--- a/synapse_pangea_chat/direct_push/direct_push.py
+++ b/synapse_pangea_chat/direct_push/direct_push.py
@@ -94,6 +94,15 @@ class DirectPush(Resource):
                 )
                 return
 
+            if not self._config.send_push_sygnal_url:
+                respond_with_json(
+                    request,
+                    500,
+                    {"error": "send_push_sygnal_url is not configured"},
+                    send_cors=True,
+                )
+                return
+
             response = await self._send_push(target_user_id, device_id, body)
             respond_with_json(request, 200, response, send_cors=True)
 
@@ -241,7 +250,7 @@ class DirectPush(Resource):
     async def _post_to_sygnal(self, payload: Dict[str, Any]) -> bool:
         try:
             agent = Agent(reactor)
-            url = b"https://sygnal.pangea.chat/_matrix/push/v1/notify"
+            url = self._config.send_push_sygnal_url.encode("utf-8")
             body_bytes = json.dumps(payload).encode("utf-8")
 
             producer = FileBodyProducer(BytesIO(body_bytes))

--- a/tests/test_direct_push_e2e.py
+++ b/tests/test_direct_push_e2e.py
@@ -8,6 +8,16 @@ from .base_e2e import BaseSynapseE2ETest
 class TestDirectPushE2E(BaseSynapseE2ETest):
     """E2E tests for direct push endpoint."""
 
+    @staticmethod
+    def _module_config(
+        send_push_sygnal_url: str
+        | None = "https://sygnal.example.test/_matrix/push/v1/notify",
+    ):
+        config = {}
+        if send_push_sygnal_url is not None:
+            config["send_push_sygnal_url"] = send_push_sygnal_url
+        return config
+
     def setUp(self):
         super().setUp()
         request_log.clear()
@@ -25,7 +35,7 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             server_process,
             stdout_thread,
             stderr_thread,
-        ) = await self.start_test_synapse()
+        ) = await self.start_test_synapse(module_config=self._module_config())
 
         try:
             await self.register_user(
@@ -62,7 +72,7 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             server_process,
             stdout_thread,
             stderr_thread,
-        ) = await self.start_test_synapse()
+        ) = await self.start_test_synapse(module_config=self._module_config())
 
         try:
             await self.register_user(
@@ -95,7 +105,7 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             server_process,
             stdout_thread,
             stderr_thread,
-        ) = await self.start_test_synapse()
+        ) = await self.start_test_synapse(module_config=self._module_config())
 
         try:
             await self.register_user(
@@ -138,7 +148,7 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             server_process,
             stdout_thread,
             stderr_thread,
-        ) = await self.start_test_synapse()
+        ) = await self.start_test_synapse(module_config=self._module_config())
 
         try:
             await self.register_user(
@@ -202,7 +212,7 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             server_process,
             stdout_thread,
             stderr_thread,
-        ) = await self.start_test_synapse()
+        ) = await self.start_test_synapse(module_config=self._module_config())
 
         try:
             await self.register_user(
@@ -233,6 +243,68 @@ class TestDirectPushE2E(BaseSynapseE2ETest):
             )
 
             self.assertEqual(response.status_code, 429)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_send_push_requires_sygnal_url_config(self):
+        """Configured pushers return an explicit 500 when Sygnal URL is unset."""
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse(module_config=self._module_config(None))
+
+        try:
+            await self.register_user(
+                config_path, synapse_dir, "alice", "pw", admin=False
+            )
+            await self.register_user(
+                config_path, synapse_dir, "admin", "pw", admin=True
+            )
+            _, alice_token = await self.login_user("alice", "pw")
+            _, admin_token = await self.login_user("admin", "pw")
+
+            pusher_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/pushers/set",
+                json={
+                    "kind": "http",
+                    "app_id": "com.talktolearn.chat",
+                    "app_display_name": "Pangea Chat",
+                    "device_display_name": "Test iPhone",
+                    "pushkey": "pushkey-1",
+                    "lang": "en",
+                    "data": {
+                        "url": "https://sygnal.staging.pangea.chat/_matrix/push/v1/notify"
+                    },
+                },
+                headers={"Authorization": f"Bearer {alice_token}"},
+            )
+            self.assertEqual(pusher_response.status_code, 200)
+
+            response = requests.post(
+                f"{self.server_url}/_synapse/client/pangea/v1/send_push",
+                json={
+                    "user_id": "@alice:my.domain.name",
+                    "room_id": "!room:test",
+                    "body": "Test",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+            self.assertEqual(response.status_code, 500)
+            self.assertEqual(
+                response.json(),
+                {"error": "send_push_sygnal_url is not configured"},
+            )
         finally:
             self.stop_synapse(
                 server_process=server_process,

--- a/tests/test_direct_push_unit.py
+++ b/tests/test_direct_push_unit.py
@@ -9,11 +9,15 @@ from synapse_pangea_chat import PangeaChat
 from synapse_pangea_chat.direct_push.direct_push import DirectPush
 
 
-def _make_handler() -> DirectPush:
+def _make_handler(
+    send_push_sygnal_url: str | None = "https://sygnal.example.test",
+) -> DirectPush:
     api = MagicMock()
     api._hs.get_auth.return_value = MagicMock()
     api._hs.get_datastores.return_value = MagicMock()
-    return DirectPush(api, MagicMock())
+    config = MagicMock()
+    config.send_push_sygnal_url = send_push_sygnal_url
+    return DirectPush(api, config)
 
 
 def _iter(items):
@@ -28,11 +32,16 @@ class TestDirectPushConfig(unittest.TestCase):
                 "cms_service_api_key": "test-api-key",
                 "send_push_requests_per_burst": 25,
                 "send_push_burst_duration_seconds": 7,
+                "send_push_sygnal_url": "https://sygnal.example.test/_matrix/push/v1/notify",
             }
         )
 
         self.assertEqual(config.send_push_requests_per_burst, 25)
         self.assertEqual(config.send_push_burst_duration_seconds, 7)
+        self.assertEqual(
+            config.send_push_sygnal_url,
+            "https://sygnal.example.test/_matrix/push/v1/notify",
+        )
 
     def test_parse_config_rejects_invalid_send_push_values(self):
         with self.assertRaisesRegex(ValueError, "send_push_requests_per_burst"):
@@ -50,6 +59,15 @@ class TestDirectPushConfig(unittest.TestCase):
                     "cms_base_url": "http://cms.example.test",
                     "cms_service_api_key": "test-api-key",
                     "send_push_burst_duration_seconds": 0,
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, 'Config "send_push_sygnal_url"'):
+            PangeaChat.parse_config(
+                {
+                    "cms_base_url": "http://cms.example.test",
+                    "cms_service_api_key": "test-api-key",
+                    "send_push_sygnal_url": "",
                 }
             )
 
@@ -215,3 +233,28 @@ class TestDirectPushHelpers(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertIsNone(payload["notification"]["devices"][0]["pushkey_ts"])
+
+    async def test_post_to_sygnal_uses_configured_url(self):
+        handler = _make_handler("https://sygnal.custom.test/_matrix/push/v1/notify")
+        fake_response = SimpleNamespace(code=200)
+        fake_agent = MagicMock()
+        fake_agent.request = AsyncMock(return_value=fake_response)
+
+        with (
+            unittest.mock.patch(
+                "synapse_pangea_chat.direct_push.direct_push.Agent",
+                return_value=fake_agent,
+            ),
+            unittest.mock.patch(
+                "synapse_pangea_chat.direct_push.direct_push.readBody",
+                new=AsyncMock(return_value=b"{}"),
+            ),
+        ):
+            result = await handler._post_to_sygnal({"notification": {}})
+
+        self.assertTrue(result)
+        fake_agent.request.assert_awaited_once()
+        self.assertEqual(
+            fake_agent.request.await_args.args[1],
+            b"https://sygnal.custom.test/_matrix/push/v1/notify",
+        )


### PR DESCRIPTION
## What
- add `send_push_sygnal_url` to direct-push module config
- return an explicit server error when direct push is used without that URL configured
- stop posting to the hardcoded production Sygnal URL
- add unit and e2e regression coverage for configured and unconfigured behavior

## Why
- Closes #72

## Testing
- `python -m unittest tests.test_direct_push_unit tests.test_direct_push_e2e`
- [ ] Staging
- [ ] Production

## Deploy Notes
- None