### PR TITLE
feat(assign-room-membership): add server-admin room assignment endpoint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ For Synapse Admin API, Module API, and Matrix spec documentation links, see [syn
 
 Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) composes sub-modules. Each sub-module lives in its own sub-package under `synapse_pangea_chat/`.
 
-**Sub-modules**: `public_courses/` ([design](instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](instructions/knock-with-code.instructions.md)), `delete_room/`, `delete_user/` + `export_user_data/` ([design](instructions/delete-user-export-user-data.instructions.md)), `user_activity/` ([design](instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](instructions/invite-by-email.instructions.md), [create_course_space](instructions/create-course-space.instructions.md)), `register_email/` ([design](instructions/register-email.instructions.md))
+**Sub-modules**: `public_courses/` ([design](instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](instructions/knock-with-code.instructions.md)), `assign_room_membership/` ([design](instructions/assign-room-membership.instructions.md)), `delete_room/`, `delete_user/` + `export_user_data/` ([design](instructions/delete-user-export-user-data.instructions.md)), `user_activity/` ([design](instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](instructions/invite-by-email.instructions.md), [create_course_space](instructions/create-course-space.instructions.md)), `register_email/` ([design](instructions/register-email.instructions.md))
 
 ## Key Files
 
@@ -18,4 +18,5 @@ Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) compos
 
 ## Feature Docs
 
+- [assign-room-membership.instructions.md](instructions/assign-room-membership.instructions.md) — server-admin endpoint for assigning local users to rooms without caller membership
 - [ensure-direct-message.instructions.md](instructions/ensure-direct-message.instructions.md) — server-admin endpoint for creating or repairing 1:1 DMs and `m.direct`

--- a/.github/instructions/assign-room-membership.instructions.md
+++ b/.github/instructions/assign-room-membership.instructions.md
@@ -1,0 +1,61 @@
+---
+applyTo: "synapse_pangea_chat/assign_room_membership/**,synapse_pangea_chat/__init__.py,tests/test_assign_room_membership_e2e.py"
+---
+
+# Assign Room Membership — Synapse Module
+
+Assigns one or more local users to a room through a server-admin endpoint without requiring the caller to already be a room member.
+
+## Endpoint
+
+`POST /_synapse/client/pangea/v1/assign_room_membership`
+
+Lives in the `assign_room_membership/` sub-package.
+
+## Contract
+
+- **Auth**: Server admin only.
+- **Request**: `{ "room_id": "!room:example.com", "user_ids": ["@user:example.com"], "force_join": true }`
+- **Validation**:
+  - `room_id` must be a valid room ID.
+  - `user_ids` must be a non-empty array of distinct local user IDs.
+  - `force_join` must be a boolean.
+
+## Behavior
+
+- Caller membership in the target room is not required.
+- `force_join: false`
+  - invite each target user unless they are already invited or already joined.
+  - do not complete the join on the user's behalf.
+- `force_join: true`
+  - ensure each target user is joined.
+  - if the room's join rules require it, the endpoint may invite first and then complete the join.
+- Partial success is part of the contract. One user's failure must not prevent attempts for the remaining users.
+
+## Per-User Results
+
+- Results are returned in request order.
+- Each result reports the target `user_id`, whether the assignment succeeded, and the primitive action outcome.
+- Successful actions are limited to `invited`, `joined`, `already_invited`, and `already_joined`.
+- Failures use `action: failed` plus an `error` string so the caller can retry or surface the failure.
+
+## Non-Goals
+
+- Power-level changes.
+- `m.direct` repair or DM-specific orchestration.
+- Access-token minting or returning access tokens.
+- Remote or federated target users.
+- Automatic unban or other membership-state repair beyond room assignment.
+
+## Future Work
+
+_Last updated: 2026-04-21_
+
+**Bot rollout**
+
+- [pangeachat/pangea-bot#1159](https://github.com/pangeachat/pangea-bot/issues/1159) — Integrate room-assignment endpoint in join_and_play and analytics access
+- [pangeachat/pangea-bot#1142](https://github.com/pangeachat/pangea-bot/issues/1142) — Audit bot impersonation call sites and propose Synapse admin endpoint workaround
+
+**Impersonation cleanup**
+
+- [pangeachat/pangea-bot#1150](https://github.com/pangeachat/pangea-bot/issues/1150) — Remove generic user access token minting after impersonation migrations land

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Mapping, Tuple
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi
 
+from synapse_pangea_chat.assign_room_membership import AssignRoomMembership
 from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.delete_room import DeleteRoom
 from synapse_pangea_chat.delete_user import DeleteUser
@@ -142,6 +143,13 @@ class PangeaChat:
         self._api.register_web_resource(
             path="/_synapse/client/pangea/v1/register/email/requestToken",
             resource=self.register_email_resource,
+        )
+
+        # --- Assign Room Membership ---
+        self.assign_room_membership_resource = AssignRoomMembership(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/assign_room_membership",
+            resource=self.assign_room_membership_resource,
         )
 
         # --- Direct Message ---

--- a/synapse_pangea_chat/assign_room_membership/__init__.py
+++ b/synapse_pangea_chat/assign_room_membership/__init__.py
@@ -1,0 +1,5 @@
+from synapse_pangea_chat.assign_room_membership.assign_room_membership import (
+    AssignRoomMembership,
+)
+
+__all__ = ["AssignRoomMembership"]

--- a/synapse_pangea_chat/assign_room_membership/assign_room_membership.py
+++ b/synapse_pangea_chat/assign_room_membership/assign_room_membership.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from synapse.api.constants import EventTypes, JoinRules
+from synapse.api.errors import (
+    AuthError,
+    InvalidClientCredentialsError,
+    InvalidClientTokenError,
+    MissingClientTokenError,
+)
+from synapse.http import server
+from synapse.http.server import respond_with_json
+from synapse.http.site import SynapseRequest
+from synapse.module_api import ModuleApi
+from synapse.types import RoomID
+from twisted.internet import defer
+from twisted.web.resource import Resource
+
+from synapse_pangea_chat.room_code.extract_body_json import extract_body_json
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger(
+    "synapse.module.synapse_pangea_chat.assign_room_membership.assign_room_membership"
+)
+
+MEMBERSHIP_BAN = "ban"
+MEMBERSHIP_INVITE = "invite"
+MEMBERSHIP_JOIN = "join"
+
+
+class AssignRoomMembership(Resource):
+    isLeaf = True
+
+    def __init__(self, api: ModuleApi, config: PangeaChatConfig):
+        super().__init__()
+        self._api = api
+        self._config = config
+        self._auth = self._api._hs.get_auth()
+        self._datastores = self._api._hs.get_datastores()
+        self._storage_controllers = self._api._hs.get_storage_controllers()
+
+    def render_POST(self, request: SynapseRequest):
+        defer.ensureDeferred(self._async_render_POST(request))
+        return server.NOT_DONE_YET
+
+    async def _async_render_POST(self, request: SynapseRequest):
+        try:
+            requester = await self._auth.get_user_by_req(request)
+            requester_id = requester.user.to_string()
+
+            if not await self._api.is_user_admin(requester_id):
+                respond_with_json(
+                    request, 403, {"error": "Admin access required"}, send_cors=True
+                )
+                return
+
+            body = await extract_body_json(request)
+            if not isinstance(body, dict):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "Request body must be a JSON object"},
+                    send_cors=True,
+                )
+                return
+
+            room_id = body.get("room_id")
+            if not isinstance(room_id, str) or not self._is_valid_room_id(room_id):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "'room_id' must be a valid room ID"},
+                    send_cors=True,
+                )
+                return
+
+            force_join = body.get("force_join")
+            if not isinstance(force_join, bool):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "'force_join' must be a boolean"},
+                    send_cors=True,
+                )
+                return
+
+            user_ids = self._extract_user_ids(body)
+            if user_ids is None:
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": (
+                            "'user_ids' must be a non-empty array of distinct local user IDs"
+                        )
+                    },
+                    send_cors=True,
+                )
+                return
+
+            canonical_user_ids = await self._validate_local_users(user_ids)
+            if canonical_user_ids is None:
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": (
+                            "'user_ids' must be a non-empty array of distinct local user IDs"
+                        )
+                    },
+                    send_cors=True,
+                )
+                return
+
+            if not await self._room_exists(room_id):
+                respond_with_json(
+                    request,
+                    404,
+                    {"error": "Room not found"},
+                    send_cors=True,
+                )
+                return
+
+            results = []
+            for user_id in canonical_user_ids:
+                results.append(
+                    await self._assign_user(
+                        requester=requester,
+                        room_id=room_id,
+                        user_id=user_id,
+                        force_join=force_join,
+                    )
+                )
+
+            respond_with_json(
+                request,
+                200,
+                {
+                    "room_id": room_id,
+                    "force_join": force_join,
+                    "results": results,
+                },
+                send_cors=True,
+            )
+        except (
+            MissingClientTokenError,
+            InvalidClientTokenError,
+            InvalidClientCredentialsError,
+            AuthError,
+        ) as e:
+            logger.info("Authentication failed: %s", e)
+            respond_with_json(
+                request,
+                401,
+                {"error": "Unauthorized", "errcode": "M_UNAUTHORIZED"},
+                send_cors=True,
+            )
+        except Exception:
+            logger.exception("Error assigning room membership")
+            respond_with_json(
+                request, 500, {"error": "Internal server error"}, send_cors=True
+            )
+
+    def _is_valid_room_id(self, room_id: str) -> bool:
+        try:
+            RoomID.from_string(room_id)
+        except Exception:
+            return False
+        return True
+
+    def _extract_user_ids(self, body: Any) -> list[str] | None:
+        user_ids = body.get("user_ids")
+        if not isinstance(user_ids, list) or not user_ids:
+            return None
+
+        if not all(isinstance(user_id, str) for user_id in user_ids):
+            return None
+
+        if len(user_ids) != len(set(user_ids)):
+            return None
+
+        return user_ids
+
+    async def _validate_local_users(self, user_ids: list[str]) -> list[str] | None:
+        canonical_user_ids: list[str] = []
+        seen_user_ids: set[str] = set()
+
+        for user_id in user_ids:
+            canonical_user_id = await self._api.check_user_exists(user_id)
+            if canonical_user_id is None or not self._api.is_mine(canonical_user_id):
+                return None
+            if canonical_user_id in seen_user_ids:
+                return None
+            seen_user_ids.add(canonical_user_id)
+            canonical_user_ids.append(canonical_user_id)
+
+        return canonical_user_ids
+
+    async def _room_exists(self, room_id: str) -> bool:
+        create_event = await self._storage_controllers.state.get_current_state_event(
+            room_id, EventTypes.Create, ""
+        )
+        return create_event is not None
+
+    async def _assign_user(
+        self,
+        requester: Any,
+        room_id: str,
+        user_id: str,
+        force_join: bool,
+    ) -> dict[str, Any]:
+        (
+            current_membership,
+            _,
+        ) = await self._datastores.main.get_local_current_membership_for_user_in_room(
+            user_id, room_id
+        )
+
+        if current_membership == MEMBERSHIP_JOIN:
+            return self._success_result(user_id, "already_joined")
+
+        if current_membership == MEMBERSHIP_INVITE and not force_join:
+            return self._success_result(user_id, "already_invited")
+
+        if current_membership == MEMBERSHIP_BAN:
+            return self._failure_result(user_id, "User is banned from room")
+
+        try:
+            if force_join:
+                await self._join_user_as_admin(
+                    user_id=user_id,
+                    room_id=room_id,
+                    current_membership=current_membership,
+                )
+                return self._success_result(user_id, "joined")
+
+            await self._invite_user_as_admin(
+                user_id=user_id,
+                room_id=room_id,
+            )
+            return self._success_result(user_id, "invited")
+        except Exception as e:
+            logger.info(
+                "Failed assigning room membership for %s in %s: %s",
+                user_id,
+                room_id,
+                e,
+            )
+            return self._failure_result(user_id, str(e) or "Room assignment failed")
+
+    async def _invite_user_as_admin(self, user_id: str, room_id: str) -> None:
+        inviter_user_id = await self._get_local_inviter_user_id(room_id)
+        if inviter_user_id is None:
+            raise RuntimeError("No local joined inviter with sufficient power")
+
+        await self._api.update_room_membership(
+            sender=inviter_user_id,
+            target=user_id,
+            room_id=room_id,
+            new_membership=MEMBERSHIP_INVITE,
+        )
+
+    async def _join_user_as_admin(
+        self,
+        user_id: str,
+        room_id: str,
+        current_membership: str | None,
+    ) -> None:
+        join_rules_event = (
+            await self._storage_controllers.state.get_current_state_event(
+                room_id, EventTypes.JoinRules, ""
+            )
+        )
+        if (
+            current_membership != MEMBERSHIP_INVITE
+            and join_rules_event is not None
+            and join_rules_event.content.get("join_rule") != JoinRules.PUBLIC
+        ):
+            await self._invite_user_as_admin(
+                user_id=user_id,
+                room_id=room_id,
+            )
+
+        await self._api.update_room_membership(
+            sender=user_id,
+            target=user_id,
+            room_id=room_id,
+            new_membership=MEMBERSHIP_JOIN,
+        )
+
+    async def _get_local_inviter_user_id(self, room_id: str) -> str | None:
+        room_state = await self._api.get_room_state(
+            room_id=room_id,
+            event_filter=[
+                (EventTypes.Create, ""),
+                (EventTypes.PowerLevels, ""),
+                (EventTypes.Member, None),
+            ],
+        )
+
+        create_event = room_state.get((EventTypes.Create, ""))
+        power_levels_event = room_state.get((EventTypes.PowerLevels, ""))
+
+        local_joined_members: set[str] = set()
+        for state_event in room_state.values():
+            if state_event.type != EventTypes.Member:
+                continue
+            if state_event.content.get("membership") != MEMBERSHIP_JOIN:
+                continue
+            user_id = state_event.state_key
+            if not isinstance(user_id, str) or not self._api.is_mine(user_id):
+                continue
+            local_joined_members.add(user_id)
+
+        if not local_joined_members:
+            return None
+
+        invite_power = 0
+        users_default = 0
+        users_power_levels: dict[str, Any] = {}
+        creator_power_users: set[str] = set()
+
+        if power_levels_event is not None:
+            invite_power = self._coerce_int(power_levels_event.content.get("invite"), 0)
+            users_default = self._coerce_int(
+                power_levels_event.content.get("users_default"), 0
+            )
+            raw_users_power_levels = power_levels_event.content.get("users", {})
+            if isinstance(raw_users_power_levels, dict):
+                users_power_levels = dict(raw_users_power_levels)
+
+        if (
+            create_event is not None
+            and create_event.room_version.msc4289_creator_power_enabled
+        ):
+            creators = create_event.content.get("additional_creators", []) + [
+                create_event.sender
+            ]
+            for creator in creators:
+                if isinstance(creator, str) and creator in local_joined_members:
+                    creator_power_users.add(creator)
+
+        candidate_users = sorted(local_joined_members)
+        best_candidate: tuple[int, str] | None = None
+        for candidate_user_id in candidate_users:
+            candidate_power = users_default
+            if candidate_user_id in creator_power_users:
+                candidate_power = 100
+            elif candidate_user_id in users_power_levels:
+                candidate_power = self._coerce_int(
+                    users_power_levels[candidate_user_id], users_default
+                )
+
+            candidate = (candidate_power, candidate_user_id)
+            if best_candidate is None or candidate > best_candidate:
+                best_candidate = candidate
+
+        if best_candidate is None or best_candidate[0] < invite_power:
+            return None
+
+        return best_candidate[1]
+
+    def _coerce_int(self, value: Any, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _success_result(self, user_id: str, action: str) -> dict[str, Any]:
+        return {"user_id": user_id, "success": True, "action": action}
+
+    def _failure_result(self, user_id: str, error: str) -> dict[str, Any]:
+        return {
+            "user_id": user_id,
+            "success": False,
+            "action": "failed",
+            "error": error,
+        }

--- a/tests/test_assign_room_membership_e2e.py
+++ b/tests/test_assign_room_membership_e2e.py
@@ -1,0 +1,399 @@
+from urllib.parse import quote
+
+import requests
+
+from .base_e2e import BaseSynapseE2ETest
+
+
+class TestAssignRoomMembershipE2E(BaseSynapseE2ETest):
+    def _endpoint(self) -> str:
+        return f"{self.server_url}/_synapse/client/pangea/v1/assign_room_membership"
+
+    def _headers(self, access_token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    def _joined_rooms_url(self) -> str:
+        return f"{self.server_url}/_matrix/client/v3/joined_rooms"
+
+    def _member_state_url(self, room_id: str, user_id: str) -> str:
+        room_id_path = quote(room_id, safe="")
+        user_id_path = quote(user_id, safe="")
+        return (
+            f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}"
+            f"/state/m.room.member/{user_id_path}"
+        )
+
+    def _ban_url(self, room_id: str) -> str:
+        room_id_path = quote(room_id, safe="")
+        return f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}/ban"
+
+    async def test_admin_only(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "owner", "pw", False)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            _, owner_token = await self.login_user("owner", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            room_id = await self.create_private_room(owner_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(alice_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id],
+                    "force_join": False,
+                },
+            )
+
+            self.assertEqual(response.status_code, 403)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_invites_users_without_joining_when_force_join_false(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "owner", "pw", False)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            await self.register_user(config_path, synapse_dir, "bob", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            _, owner_token = await self.login_user("owner", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            bob_user_id, bob_token = await self.login_user("bob", "pw")
+            room_id = await self.create_private_room(owner_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id, bob_user_id],
+                    "force_join": False,
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["room_id"], room_id)
+            self.assertFalse(data["force_join"])
+            self.assertEqual(
+                data["results"],
+                [
+                    {
+                        "user_id": alice_user_id,
+                        "success": True,
+                        "action": "invited",
+                    },
+                    {
+                        "user_id": bob_user_id,
+                        "success": True,
+                        "action": "invited",
+                    },
+                ],
+            )
+
+            alice_member_state = requests.get(
+                self._member_state_url(room_id, alice_user_id),
+                headers=self._headers(owner_token),
+            )
+            self.assertEqual(alice_member_state.status_code, 200)
+            self.assertEqual(alice_member_state.json()["membership"], "invite")
+
+            bob_member_state = requests.get(
+                self._member_state_url(room_id, bob_user_id),
+                headers=self._headers(owner_token),
+            )
+            self.assertEqual(bob_member_state.status_code, 200)
+            self.assertEqual(bob_member_state.json()["membership"], "invite")
+
+            alice_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(alice_token)
+            )
+            self.assertEqual(alice_joined.status_code, 200)
+            self.assertNotIn(room_id, alice_joined.json()["joined_rooms"])
+
+            bob_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(bob_token)
+            )
+            self.assertEqual(bob_joined.status_code, 200)
+            self.assertNotIn(room_id, bob_joined.json()["joined_rooms"])
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_force_joins_users_when_force_join_true(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "owner", "pw", False)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            await self.register_user(config_path, synapse_dir, "bob", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            _, owner_token = await self.login_user("owner", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            bob_user_id, bob_token = await self.login_user("bob", "pw")
+            room_id = await self.create_private_room(owner_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id, bob_user_id],
+                    "force_join": True,
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertTrue(data["force_join"])
+            self.assertEqual(
+                data["results"],
+                [
+                    {
+                        "user_id": alice_user_id,
+                        "success": True,
+                        "action": "joined",
+                    },
+                    {
+                        "user_id": bob_user_id,
+                        "success": True,
+                        "action": "joined",
+                    },
+                ],
+            )
+
+            alice_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(alice_token)
+            )
+            self.assertEqual(alice_joined.status_code, 200)
+            self.assertIn(room_id, alice_joined.json()["joined_rooms"])
+
+            bob_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(bob_token)
+            )
+            self.assertEqual(bob_joined.status_code, 200)
+            self.assertIn(room_id, bob_joined.json()["joined_rooms"])
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_returns_partial_results_when_one_user_is_banned(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "owner", "pw", False)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            await self.register_user(config_path, synapse_dir, "bob", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            _, owner_token = await self.login_user("owner", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            bob_user_id, bob_token = await self.login_user("bob", "pw")
+            room_id = await self.create_private_room(owner_token)
+
+            invited = await self.invite_user_to_room(
+                room_id, alice_user_id, owner_token
+            )
+            self.assertTrue(invited)
+            joined = await self.accept_room_invitation(room_id, alice_token)
+            self.assertTrue(joined)
+
+            invited_bob = await self.invite_user_to_room(
+                room_id, bob_user_id, owner_token
+            )
+            self.assertTrue(invited_bob)
+            ban_response = requests.post(
+                self._ban_url(room_id),
+                headers=self._headers(owner_token),
+                json={"user_id": bob_user_id},
+            )
+            self.assertEqual(ban_response.status_code, 200)
+
+            banned_member_state = requests.get(
+                self._member_state_url(room_id, bob_user_id),
+                headers=self._headers(owner_token),
+            )
+            self.assertEqual(banned_member_state.status_code, 200)
+            self.assertEqual(banned_member_state.json()["membership"], "ban")
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id, bob_user_id],
+                    "force_join": True,
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.json()["results"],
+                [
+                    {
+                        "user_id": alice_user_id,
+                        "success": True,
+                        "action": "already_joined",
+                    },
+                    {
+                        "user_id": bob_user_id,
+                        "success": False,
+                        "action": "failed",
+                        "error": "User is banned from room",
+                    },
+                ],
+            )
+
+            alice_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(alice_token)
+            )
+            self.assertEqual(alice_joined.status_code, 200)
+            self.assertIn(room_id, alice_joined.json()["joined_rooms"])
+
+            bob_joined = requests.get(
+                self._joined_rooms_url(), headers=self._headers(bob_token)
+            )
+            self.assertEqual(bob_joined.status_code, 200)
+            self.assertNotIn(room_id, bob_joined.json()["joined_rooms"])
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_rejects_duplicate_and_non_local_user_ids(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "owner", "pw", False)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            _, owner_token = await self.login_user("owner", "pw")
+            alice_user_id, _ = await self.login_user("alice", "pw")
+            room_id = await self.create_private_room(owner_token)
+
+            duplicate_response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id, alice_user_id],
+                    "force_join": False,
+                },
+            )
+            self.assertEqual(duplicate_response.status_code, 400)
+
+            remote_response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": room_id,
+                    "user_ids": [alice_user_id, "@remote:elsewhere.example"],
+                    "force_join": False,
+                },
+            )
+            self.assertEqual(remote_response.status_code, 400)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_returns_404_for_missing_room(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            alice_user_id, _ = await self.login_user("alice", "pw")
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={
+                    "room_id": "!missing:my.domain.name",
+                    "user_ids": [alice_user_id],
+                    "force_join": False,
+                },
+            )
+
+            self.assertEqual(response.status_code, 404)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )


### PR DESCRIPTION
## What

Add a server-admin endpoint that assigns local users to rooms without requiring caller membership, plus the matching instruction doc and E2E coverage.

## Why

Closes #74

## Testing

- `/Users/wilsonle/dev/pangea-chat/synapse-pangea-chat-modules/.venv/bin/python -m unittest tests.test_assign_room_membership_e2e`
- `/Users/wilsonle/dev/pangea-chat/synapse-pangea-chat-modules/.venv/bin/python -m unittest tests.test_direct_message_e2e`
- `/Users/wilsonle/dev/pangea-chat/synapse-pangea-chat-modules/.venv/bin/black --check synapse_pangea_chat/assign_room_membership/assign_room_membership.py synapse_pangea_chat/__init__.py tests/test_assign_room_membership_e2e.py`
- `/Users/wilsonle/dev/pangea-chat/synapse-pangea-chat-modules/.venv/bin/ruff check synapse_pangea_chat/assign_room_membership/assign_room_membership.py synapse_pangea_chat/__init__.py tests/test_assign_room_membership_e2e.py`

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None