### PR TITLE
docs(direct_push): document roomless send_push behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ For Synapse Admin API, Module API, and Matrix spec documentation links, see [syn
 
 Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) composes sub-modules. Each sub-module lives in its own sub-package under `synapse_pangea_chat/`.
 
-**Sub-modules**: `public_courses/` ([design](instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](instructions/knock-with-code.instructions.md)), `assign_room_membership/` ([design](instructions/assign-room-membership.instructions.md)), `delete_room/`, `delete_user/` + `export_user_data/` ([design](instructions/delete-user-export-user-data.instructions.md)), `user_activity/` ([design](instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](instructions/invite-by-email.instructions.md), [create_course_space](instructions/create-course-space.instructions.md)), `register_email/` ([design](instructions/register-email.instructions.md))
+**Sub-modules**: `public_courses/` ([design](instructions/public-courses.instructions.md)), `room_preview/`, `room_code/` ([design](instructions/knock-with-code.instructions.md)), `assign_room_membership/` ([design](instructions/assign-room-membership.instructions.md)), `delete_room/`, `delete_user/` + `export_user_data/` ([design](instructions/delete-user-export-user-data.instructions.md)), `user_activity/` ([design](instructions/user-activity.instructions.md)), `limit_user_directory/` + `user_directory_search/` ([design](instructions/limit-user-directory.instructions.md)), `email_invite/` ([invite_by_email](instructions/invite-by-email.instructions.md), [create_course_space](instructions/create-course-space.instructions.md)), `register_email/` ([design](instructions/register-email.instructions.md)), `direct_push/` ([design](instructions/direct-push.instructions.md))
 
 ## Key Files
 
@@ -19,4 +19,5 @@ Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) compos
 ## Feature Docs
 
 - [assign-room-membership.instructions.md](instructions/assign-room-membership.instructions.md) — server-admin endpoint for assigning local users to rooms without caller membership
+- [direct-push.instructions.md](instructions/direct-push.instructions.md) — server-admin endpoint for roomless lower-level push delivery without Matrix event persistence
 - [ensure-direct-message.instructions.md](instructions/ensure-direct-message.instructions.md) — server-admin endpoint for creating or repairing 1:1 DMs and `m.direct`

--- a/.github/instructions/direct-push.instructions.md
+++ b/.github/instructions/direct-push.instructions.md
@@ -1,0 +1,62 @@
+---
+applyTo: "synapse_pangea_chat/direct_push/**,synapse_pangea_chat/config.py,synapse_pangea_chat/__init__.py,tests/test_direct_push*.py"
+---
+
+# Direct Push — Synapse Module
+
+Admin-only endpoint for sending a roomless push notification to a local user.
+
+For Synapse Admin API, Module API, and Matrix spec documentation links, see [synapse-docs.instructions.md](../../../.github/.github/instructions/synapse-docs.instructions.md).
+
+## Endpoint
+
+`POST /_synapse/client/pangea/v1/send_push`
+
+Lives in the `direct_push/` sub-package.
+
+## Contract
+
+- **Auth**: Server admin only.
+- **Request**: Requires `user_id` and `body`.
+- **Optional request fields**: `device_id`, `room_id`, `event_id`, `type`, `content`, and `prio`.
+- **Response**: Returns delivery attempts and errors for the transport path the endpoint invoked itself. It does not imply that a Matrix event was persisted or that every Synapse pusher kind was exercised.
+
+## Behavior
+
+- Works below the Matrix event layer.
+- Does not forge or persist a Matrix event.
+- Does not create timeline entries, unread state, receipts, or `event_push_actions`.
+- This roomless behavior is intentional: callers can send a push notification without attaching it to any room.
+- The current implementation delivers through its own lower-level transport path rather than delegating to Synapse's normal event-driven notification pipeline.
+
+## Current Limitation
+
+- The endpoint is roomless by design, but that also means it is not truly pusher-agnostic in practice.
+- Pushers that depend on Matrix event persistence are not triggered by default.
+- In particular, normal email notification delivery is not produced automatically by this endpoint.
+
+## Intended Use
+
+- Operational or bot-driven nudges where roomless delivery is required.
+- Transporting a push payload to a user who already has compatible pushers configured on the homeserver.
+
+## Non-Goals
+
+- Creating a canonical chat or room-history record of the notification.
+- Reusing room notification semantics such as unread counts or reopen tracking.
+- Guaranteeing identical behavior across every configured pusher kind.
+
+## Key Files
+
+- [`direct_push.py`](../../synapse_pangea_chat/direct_push/direct_push.py) — admin-only roomless push endpoint
+- [`__init__.py`](../../synapse_pangea_chat/__init__.py) — resource registration
+- [`config.py`](../../synapse_pangea_chat/config.py) — direct-push config fields
+- [`test_direct_push_e2e.py`](../../tests/test_direct_push_e2e.py) — endpoint behavior coverage
+
+## Future Work
+
+_Last updated: 2026-04-22_
+
+**Endpoint semantics**
+
+- [pangeachat/synapse-pangea-chat#79](https://github.com/pangeachat/synapse-pangea-chat/issues/79) — Add optional email delivery flag to direct-push endpoint

--- a/synapse_pangea_chat/direct_push/direct_push.py
+++ b/synapse_pangea_chat/direct_push/direct_push.py
@@ -35,6 +35,14 @@ logger = logging.getLogger("synapse.module.synapse_pangea_chat.direct_push")
 
 
 class DirectPush(Resource):
+    """Admin-only roomless push endpoint.
+
+    This path intentionally bypasses Matrix event persistence so callers can
+    deliver a push payload without attaching it to any room. The tradeoff is
+    that event-driven notification behavior, including normal email delivery,
+    is not triggered automatically by default.
+    """
+
     isLeaf = True
 
     def __init__(self, api: ModuleApi, config: PangeaChatConfig):


### PR DESCRIPTION
## What

Document the direct-push endpoint as a roomless, non-event-driven notification path, add a dedicated instruction doc, and link a follow-up issue for optional email delivery.

## Why

Closes #78

## Testing

- `python3 -m py_compile synapse_pangea_chat/direct_push/direct_push.py`
- No client testing needed — docs/instruction updates only, no user-facing app behavior change.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None