### PR TITLE
feat(user_activity): add server-side filter params to user_activity endpoint

### DIFF
--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -48,6 +48,9 @@ class PangeaChatConfig:
     # --- user_activity config ---
     user_activity_requests_per_burst: int = 10
     user_activity_burst_duration_seconds: int = 60
+    # Bot user ID used by the notification_cooldown_ms filter to identify bot DM rooms.
+    # Required when using the notification_cooldown_ms query param.
+    user_activity_notification_bot_user_id: Optional[str] = None
 
     # --- delete_user config ---
     delete_user_requests_per_burst: int = 5

--- a/synapse_pangea_chat/user_activity/get_users.py
+++ b/synapse_pangea_chat/user_activity/get_users.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, List, Optional, Set
 
+from synapse.module_api import ModuleApi
 from synapse.storage.databases.main.room import RoomStore
 
 logger = logging.getLogger("synapse_pangea_chat.user_activity.get_users")
@@ -14,8 +16,29 @@ async def get_users(
     *,
     page: int = 1,
     limit: int = 50,
+    user_ids: Optional[List[str]] = None,
+    course_ids: Optional[List[str]] = None,
+    inactive_days: Optional[int] = None,
+    notification_cooldown_ms: Optional[int] = None,
+    bot_user_id: Optional[str] = None,
+    api: Optional[ModuleApi] = None,
 ) -> Dict[str, Any]:
     """Return paginated list of local users with basic activity metadata.
+
+    Filter params (all optional, composable):
+      user_ids               - restrict to these user IDs
+      course_ids             - restrict to members of these course rooms
+      inactive_days          - only users where max(last_login_ts, last_message_ts)
+                               is older than this many days, or who have no activity
+      notification_cooldown_ms - exclude users who have a p.room.notice from
+                               bot_user_id in their bot DM room within the last N ms.
+                               Requires api and bot_user_id to be set.
+                               WARNING: performs O(N candidates) account-data lookups
+                               when no user_ids/course_ids narrow the set.
+
+    When user_ids and course_ids are both provided the result is their intersection.
+
+    totalDocs and maxPage always reflect the fully-filtered count.
 
     Response shape:
         {
@@ -30,47 +53,286 @@ async def get_users(
     Course memberships are available via the separate user_courses endpoint.
     """
 
-    # --- 1. Count total users -------------------------------------------------
-    count_query = """
-    SELECT COUNT(*) FROM users u
-    WHERE u.deactivated = 0 AND u.is_guest = 0
-    """
-    count_rows = await room_store.db_pool.execute("get_users_count", count_query)
-    total_docs: int = count_rows[0][0] if count_rows else 0
+    # ------------------------------------------------------------------
+    # Step 1 — resolve id_filter from user_ids / course_ids
+    # ------------------------------------------------------------------
+    id_filter: Optional[Set[str]] = None
 
+    if course_ids:
+        course_placeholders = ",".join(["?" for _ in course_ids])
+        course_members_query = f"""
+        SELECT DISTINCT rm.user_id
+        FROM room_memberships rm
+        INNER JOIN current_state_events cse ON cse.event_id = rm.event_id
+        WHERE rm.room_id IN ({course_placeholders})
+          AND rm.membership = 'join'
+        """
+        course_member_rows = await room_store.db_pool.execute(
+            "get_users_course_members", course_members_query, *course_ids
+        )
+        course_member_ids: Set[str] = {row[0] for row in course_member_rows}
+
+        if user_ids is not None:
+            # intersection
+            id_filter = course_member_ids & set(user_ids)
+        else:
+            id_filter = course_member_ids
+    elif user_ids is not None:
+        id_filter = set(user_ids)
+    # else id_filter remains None → no ID filter
+
+    # ------------------------------------------------------------------
+    # Step 2 — build shared WHERE clause and CTE fragments
+    # ------------------------------------------------------------------
+    # inactive_days threshold: epoch-ms before which last activity must fall
+    inactivity_threshold_ms: Optional[int] = None
+    if inactive_days is not None:
+        inactivity_threshold_ms = int(time.time() * 1000) - inactive_days * 86_400_000
+
+    def _build_extra_where() -> tuple[str, list[Any]]:
+        """Return (extra WHERE snippet, positional args list).
+
+        The snippet begins with ' AND ' when non-empty so it can be appended
+        directly after the base ``WHERE u.deactivated = 0 AND u.is_guest = 0``.
+        """
+        clauses: list[str] = []
+        args: list[Any] = []
+
+        if id_filter is not None:
+            if not id_filter:
+                # Empty filter → guaranteed zero results
+                clauses.append("1 = 0")
+            else:
+                placeholders = ",".join(["?" for _ in id_filter])
+                clauses.append(f"u.name IN ({placeholders})")
+                args.extend(sorted(id_filter))  # sort for stable query plans
+
+        if inactivity_threshold_ms is not None:
+            clauses.append(
+                "COALESCE(ll.last_login_ts, 0) < ?"
+                " AND COALESCE(lm.last_message_ts, 0) < ?"
+            )
+            args.extend([inactivity_threshold_ms, inactivity_threshold_ms])
+
+        if clauses:
+            return " AND " + " AND ".join(clauses), args
+        return "", args
+
+    needs_inactive_ctes = inactivity_threshold_ms is not None
+
+    def _inactive_ctes() -> str:
+        return """
+    WITH last_logins AS (
+        SELECT user_id, MAX(last_seen) AS last_login_ts
+        FROM user_ips
+        GROUP BY user_id
+    ),
+    last_messages AS (
+        SELECT sender, MAX(origin_server_ts) AS last_message_ts
+        FROM events
+        WHERE type = 'm.room.message'
+        GROUP BY sender
+    )
+    """
+
+    def _login_cte() -> str:
+        return """
+    WITH last_logins AS (
+        SELECT user_id, MAX(last_seen) AS last_login_ts
+        FROM user_ips
+        GROUP BY user_id
+    )
+    """
+
+    # ------------------------------------------------------------------
+    # Path A — no notification_cooldown_ms: SQL handles count + pagination
+    # ------------------------------------------------------------------
+    if notification_cooldown_ms is None:
+        extra_where, filter_args = _build_extra_where()
+
+        if needs_inactive_ctes:
+            count_query = f"""
+            {_inactive_ctes()}
+            SELECT COUNT(*)
+            FROM users u
+            LEFT JOIN last_logins ll ON ll.user_id = u.name
+            LEFT JOIN last_messages lm ON lm.sender = u.name
+            WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+            """
+        else:
+            count_query = f"""
+            SELECT COUNT(*)
+            FROM users u
+            WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+            """
+
+        count_rows = await room_store.db_pool.execute(
+            "get_users_count", count_query, *filter_args
+        )
+        total_docs: int = count_rows[0][0] if count_rows else 0
+
+        max_page = max(1, math.ceil(total_docs / limit))
+        if page < 1:
+            page = 1
+        if page > max_page:
+            page = max_page
+        offset = (page - 1) * limit
+
+        if needs_inactive_ctes:
+            users_query = f"""
+            {_inactive_ctes()}
+            SELECT
+                u.name AS user_id,
+                p.displayname AS display_name,
+                COALESCE(ll.last_login_ts, 0) AS last_login_ts,
+                COALESCE(lm.last_message_ts, 0) AS last_message_ts
+            FROM users u
+            LEFT JOIN profiles p ON p.full_user_id = u.name
+            LEFT JOIN last_logins ll ON ll.user_id = u.name
+            LEFT JOIN last_messages lm ON lm.sender = u.name
+            WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+            ORDER BY u.name
+            LIMIT ? OFFSET ?
+            """
+            user_rows = await room_store.db_pool.execute(
+                "get_users_page", users_query, *filter_args, limit, offset
+            )
+        else:
+            users_query = f"""
+            {_login_cte()}
+            SELECT
+                u.name AS user_id,
+                p.displayname AS display_name,
+                COALESCE(ll.last_login_ts, 0) AS last_login_ts
+            FROM users u
+            LEFT JOIN profiles p ON p.full_user_id = u.name
+            LEFT JOIN last_logins ll ON ll.user_id = u.name
+            WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+            ORDER BY u.name
+            LIMIT ? OFFSET ?
+            """
+            user_rows = await room_store.db_pool.execute(
+                "get_users_page", users_query, *filter_args, limit, offset
+            )
+
+        if not user_rows:
+            return {
+                "docs": [],
+                "page": page,
+                "limit": limit,
+                "totalDocs": total_docs,
+                "maxPage": max_page,
+            }
+
+        users: List[Dict[str, Any]] = []
+        page_user_ids: List[str] = []
+
+        if needs_inactive_ctes:
+            for row in user_rows:
+                uid, display_name, last_login_ts, last_message_ts = row
+                users.append(
+                    {
+                        "user_id": uid,
+                        "display_name": display_name,
+                        "last_login_ts": last_login_ts or 0,
+                        "last_message_ts": last_message_ts or 0,
+                    }
+                )
+                page_user_ids.append(uid)
+        else:
+            for row in user_rows:
+                uid, display_name, last_login_ts = row
+                users.append(
+                    {
+                        "user_id": uid,
+                        "display_name": display_name,
+                        "last_login_ts": last_login_ts or 0,
+                        "last_message_ts": 0,
+                    }
+                )
+                page_user_ids.append(uid)
+
+            # Fetch last message ts separately (path A without inactive filter)
+            user_placeholders = ",".join(["?" for _ in page_user_ids])
+            last_message_query = f"""
+            SELECT e.sender, MAX(e.origin_server_ts) AS last_message_ts
+            FROM events e
+            WHERE e.type = 'm.room.message'
+              AND e.sender IN ({user_placeholders})
+            GROUP BY e.sender
+            """
+            message_rows = await room_store.db_pool.execute(
+                "get_users_last_message", last_message_query, *page_user_ids
+            )
+            users_by_id = {u["user_id"]: u for u in users}
+            for row in message_rows:
+                sender, last_message_ts = row
+                if sender in users_by_id:
+                    users_by_id[sender]["last_message_ts"] = last_message_ts or 0
+
+        return {
+            "docs": users,
+            "page": page,
+            "limit": limit,
+            "totalDocs": total_docs,
+            "maxPage": max_page,
+        }
+
+    # ------------------------------------------------------------------
+    # Path B — notification_cooldown_ms: full-scan then per-user filter
+    # ------------------------------------------------------------------
+    # 1. Fetch all matching candidate user IDs (SQL-filtered, no LIMIT)
+    extra_where, filter_args = _build_extra_where()
+
+    if needs_inactive_ctes:
+        candidates_query = f"""
+        {_inactive_ctes()}
+        SELECT u.name
+        FROM users u
+        LEFT JOIN last_logins ll ON ll.user_id = u.name
+        LEFT JOIN last_messages lm ON lm.sender = u.name
+        WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+        ORDER BY u.name
+        """
+    else:
+        candidates_query = f"""
+        SELECT u.name
+        FROM users u
+        WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+        ORDER BY u.name
+        """
+
+    candidate_rows = await room_store.db_pool.execute(
+        "get_users_candidates", candidates_query, *filter_args
+    )
+    candidate_ids: List[str] = [row[0] for row in candidate_rows]
+
+    # 2. Filter by notification cooldown
+    cooldown_threshold_ms = int(time.time() * 1000) - notification_cooldown_ms
+    filtered_ids: List[str] = []
+
+    for uid in candidate_ids:
+        recently_notified = await _user_recently_notified(
+            room_store=room_store,
+            api=api,
+            user_id=uid,
+            bot_user_id=bot_user_id,
+            cooldown_threshold_ms=cooldown_threshold_ms,
+        )
+        if not recently_notified:
+            filtered_ids.append(uid)
+
+    # 3. Paginate in Python now that we have the exact filtered list
+    total_docs = len(filtered_ids)
     max_page = max(1, math.ceil(total_docs / limit))
     if page < 1:
         page = 1
     if page > max_page:
         page = max_page
 
-    offset = (page - 1) * limit
+    page_ids = filtered_ids[(page - 1) * limit : page * limit]
 
-    # --- 2. Fetch page of users with last login -------------------------------
-    users_query = """
-    WITH last_logins AS (
-        SELECT user_id, MAX(last_seen) AS last_login_ts
-        FROM user_ips
-        GROUP BY user_id
-    )
-    SELECT
-        u.name AS user_id,
-        p.displayname AS display_name,
-        COALESCE(ll.last_login_ts, 0) AS last_login_ts
-    FROM users u
-    LEFT JOIN profiles p ON p.full_user_id = u.name
-    LEFT JOIN last_logins ll ON ll.user_id = u.name
-    WHERE u.deactivated = 0
-      AND u.is_guest = 0
-    ORDER BY u.name
-    LIMIT ? OFFSET ?
-    """
-
-    user_rows = await room_store.db_pool.execute(
-        "get_users_page", users_query, limit, offset
-    )
-
-    if not user_rows:
+    if not page_ids:
         return {
             "docs": [],
             "page": page,
@@ -79,32 +341,46 @@ async def get_users(
             "maxPage": max_page,
         }
 
-    users: List[Dict[str, Any]] = []
-    user_ids: List[str] = []
-    for row in user_rows:
-        user_id, display_name, last_login_ts = row
+    # 4. Fetch display_name + last_login_ts + last_message_ts for page_ids
+    page_placeholders = ",".join(["?" for _ in page_ids])
+    page_users_query = f"""
+    {_login_cte()}
+    SELECT
+        u.name AS user_id,
+        p.displayname AS display_name,
+        COALESCE(ll.last_login_ts, 0) AS last_login_ts
+    FROM users u
+    LEFT JOIN profiles p ON p.full_user_id = u.name
+    LEFT JOIN last_logins ll ON ll.user_id = u.name
+    WHERE u.name IN ({page_placeholders})
+    ORDER BY u.name
+    """
+    page_user_rows = await room_store.db_pool.execute(
+        "get_users_page_b", page_users_query, *page_ids
+    )
+
+    users = []
+    for row in page_user_rows:
+        uid, display_name, last_login_ts = row
         users.append(
             {
-                "user_id": user_id,
+                "user_id": uid,
                 "display_name": display_name,
                 "last_login_ts": last_login_ts or 0,
                 "last_message_ts": 0,
             }
         )
-        user_ids.append(user_id)
 
-    user_placeholders = ",".join(["?" for _ in user_ids])
-
-    # --- 3. Last message timestamp per user -----------------------------------
+    # Fetch last message ts
     last_message_query = f"""
     SELECT e.sender, MAX(e.origin_server_ts) AS last_message_ts
     FROM events e
     WHERE e.type = 'm.room.message'
-      AND e.sender IN ({user_placeholders})
+      AND e.sender IN ({page_placeholders})
     GROUP BY e.sender
     """
     message_rows = await room_store.db_pool.execute(
-        "get_users_last_message", last_message_query, *user_ids
+        "get_users_last_message_b", last_message_query, *page_ids
     )
     users_by_id = {u["user_id"]: u for u in users}
     for row in message_rows:
@@ -119,3 +395,55 @@ async def get_users(
         "totalDocs": total_docs,
         "maxPage": max_page,
     }
+
+
+async def _user_recently_notified(
+    *,
+    room_store: RoomStore,
+    api: Optional[ModuleApi],
+    user_id: str,
+    bot_user_id: Optional[str],
+    cooldown_threshold_ms: int,
+) -> bool:
+    """Return True if the user has a p.room.notice from bot_user_id in their
+    bot DM room with an origin_server_ts > cooldown_threshold_ms.
+
+    Returns False (do not exclude) when api/bot_user_id are None or when no
+    bot DM rooms are found.
+    """
+    if api is None or not bot_user_id:
+        return False
+
+    try:
+        m_direct = await api.account_data_manager.get_global(user_id, "m.direct")
+    except Exception:
+        logger.debug(
+            "Could not fetch m.direct account data for %s, treating as not notified",
+            user_id,
+        )
+        return False
+
+    if not m_direct:
+        return False
+
+    bot_dm_rooms: List[str] = m_direct.get(bot_user_id, [])
+    if not bot_dm_rooms:
+        return False
+
+    room_placeholders = ",".join(["?" for _ in bot_dm_rooms])
+    notice_query = f"""
+    SELECT 1 FROM events
+    WHERE room_id IN ({room_placeholders})
+      AND sender = ?
+      AND type = 'p.room.notice'
+      AND origin_server_ts > ?
+    LIMIT 1
+    """
+    notice_rows = await room_store.db_pool.execute(
+        "get_users_recent_notice",
+        notice_query,
+        *bot_dm_rooms,
+        bot_user_id,
+        cooldown_threshold_ms,
+    )
+    return bool(notice_rows)

--- a/synapse_pangea_chat/user_activity/user_activity.py
+++ b/synapse_pangea_chat/user_activity/user_activity.py
@@ -44,7 +44,25 @@ class UserActivity(_AdminResourceBase):
     """GET /_synapse/client/pangea/v1/user_activity
 
     Paginated list of local users with activity metadata.
-    Query params: page (int, default 1), limit (int, default 50, max 200).
+
+    Query params:
+      page                   int  (default 1)
+      limit                  int  (default 50, max 200)
+      user_ids               str  comma-separated Matrix user IDs to include
+      course_ids             str  comma-separated room IDs; include only
+                                  members of these course rooms
+      inactive_days          int  return only users whose
+                                  max(last_login_ts, last_message_ts) is older
+                                  than this many days (or who have no activity)
+      notification_cooldown_ms int exclude users who have a p.room.notice from
+                                  the bot in their bot DM room within the last
+                                  N ms. Requires the
+                                  user_activity_notification_bot_user_id module
+                                  config field to be set.
+
+    NOTE: notification_cooldown_ms performs O(N candidates) account-data
+    lookups server-side. Use user_ids or course_ids to narrow the candidate
+    set when possible.
     """
 
     def render_GET(self, request: SynapseRequest):
@@ -68,8 +86,39 @@ class UserActivity(_AdminResourceBase):
 
             page = _int_param(request, b"page", default=1, minimum=1)
             limit = _int_param(request, b"limit", default=50, minimum=1, maximum=200)
+            user_ids = _list_param(request, b"user_ids")
+            course_ids = _list_param(request, b"course_ids")
+            inactive_days = _optional_int_param(request, b"inactive_days", minimum=1)
+            notification_cooldown_ms = _optional_int_param(
+                request, b"notification_cooldown_ms", minimum=1
+            )
 
-            data = await get_users(self._datastores.main, page=page, limit=limit)
+            if notification_cooldown_ms is not None and not (
+                self._config.user_activity_notification_bot_user_id
+            ):
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": "notification_cooldown_ms requires the "
+                        "user_activity_notification_bot_user_id module "
+                        "config field to be set"
+                    },
+                    send_cors=True,
+                )
+                return
+
+            data = await get_users(
+                self._datastores.main,
+                page=page,
+                limit=limit,
+                user_ids=user_ids,
+                course_ids=course_ids,
+                inactive_days=inactive_days,
+                notification_cooldown_ms=notification_cooldown_ms,
+                bot_user_id=self._config.user_activity_notification_bot_user_id,
+                api=self._api,
+            )
 
             respond_with_json(request, 200, data, send_cors=True)
 
@@ -269,3 +318,32 @@ def _str_param(request: SynapseRequest, name: bytes) -> str | None:
     if isinstance(raw, bytes):
         return raw.decode("utf-8")
     return str(raw)
+
+
+def _list_param(request: SynapseRequest, name: bytes) -> list[str] | None:
+    """Parse a comma-separated multi-value query param.
+
+    Returns None if the param is absent, an empty list if the value is blank,
+    or a list of non-empty stripped strings.
+    """
+    raw = _str_param(request, name)
+    if raw is None:
+        return None
+    return [v.strip() for v in raw.split(",") if v.strip()]
+
+
+def _optional_int_param(
+    request: SynapseRequest,
+    name: bytes,
+    *,
+    minimum: int = 1,
+) -> int | None:
+    """Parse an optional integer query param. Returns None if absent or unparseable."""
+    raw = request.args.get(name, [None])[0]  # type: ignore[arg-type]
+    if raw is None:
+        return None
+    try:
+        val = int(raw)
+    except (ValueError, TypeError):
+        return None
+    return max(minimum, val)

--- a/tests/test_user_activity_e2e.py
+++ b/tests/test_user_activity_e2e.py
@@ -371,3 +371,671 @@ class TestUserActivityE2E(BaseSynapseE2ETest):
                 synapse_dir=synapse_dir,
                 postgres=postgres,
             )
+
+    async def test_user_ids_filter(self):
+        """user_ids param restricts results and totalDocs to the given users."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="user1",
+                password="pw1",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="user2",
+                password="pw2",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={"user_ids": "@user1:my.domain.name,@user2:my.domain.name"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            self.assertEqual(
+                returned_ids,
+                {"@user1:my.domain.name", "@user2:my.domain.name"},
+            )
+            self.assertEqual(data["totalDocs"], 2)
+            self.assertNotIn("@admin:my.domain.name", returned_ids)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_course_ids_filter(self):
+        """course_ids param returns only members of those course rooms."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="member",
+                password="pw1",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="nonmember",
+                password="pw2",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+            _, member_token = await self.login_user("member", "pw1")
+
+            # Create a course room
+            course_resp = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json={
+                    "preset": "public_chat",
+                    "initial_state": [
+                        {
+                            "type": "pangea.course_plan",
+                            "state_key": "",
+                            "content": {"uuid": "c1"},
+                        },
+                    ],
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(course_resp.status_code, 200)
+            course_room_id = course_resp.json()["room_id"]
+
+            # member joins the course
+            requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{course_room_id}",
+                headers={"Authorization": f"Bearer {member_token}"},
+                timeout=30,
+            )
+
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={"course_ids": course_room_id},
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            # admin (creator) and member joined; nonmember did not
+            self.assertIn("@member:my.domain.name", returned_ids)
+            self.assertNotIn("@nonmember:my.domain.name", returned_ids)
+            self.assertEqual(data["totalDocs"], len(returned_ids))
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_user_ids_course_ids_intersection(self):
+        """When both user_ids and course_ids are supplied the result is the intersection."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="userA",
+                password="pwA",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="userB",
+                password="pwB",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="userC",
+                password="pwC",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+            _, token_a = await self.login_user("userA", "pwA")
+            _, token_c = await self.login_user("userC", "pwC")
+
+            # Create course; A and C join, B does not
+            course_resp = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json={
+                    "preset": "public_chat",
+                    "initial_state": [
+                        {
+                            "type": "pangea.course_plan",
+                            "state_key": "",
+                            "content": {"uuid": "c2"},
+                        },
+                    ],
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(course_resp.status_code, 200)
+            course_room_id = course_resp.json()["room_id"]
+            requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{course_room_id}",
+                headers={"Authorization": f"Bearer {token_a}"},
+                timeout=30,
+            )
+            requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{course_room_id}",
+                headers={"Authorization": f"Bearer {token_c}"},
+                timeout=30,
+            )
+
+            # user_ids = A,B; course has A,C → intersection = A only
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={
+                    "user_ids": "@userA:my.domain.name,@userB:my.domain.name",
+                    "course_ids": course_room_id,
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            self.assertEqual(returned_ids, {"@userA:my.domain.name"})
+            self.assertEqual(data["totalDocs"], 1)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_inactive_days_filter(self):
+        """inactive_days excludes recently-active users and includes inactive ones."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="inactive_user",
+                password="pw1",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+            # Log in as inactive_user to create a user_ips entry, but
+            # inactive_days=1 (threshold = now - 86400000ms) means a just-logged-in
+            # admin will be excluded while inactive_user (no subsequent activity
+            # after login) will also fail the threshold immediately after login.
+            # Instead we use inactive_days=0 equivalent via minimum clamp to 1 day,
+            # and rely on the fact that inactive_user has never sent a message and
+            # a very large inactive_days filter to guarantee the admin's fresh login
+            # would NOT pass.
+            # For a deterministic test we filter by user_ids so we control exactly
+            # which user is checked.
+            _, _inactive_token = await self.login_user("inactive_user", "pw1")
+
+            # Wait for user_ips flush
+            await asyncio.sleep(6)
+
+            # inactive_days=3650 (10 years) — nobody logged in 10 years ago
+            # so both users pass. Verify both are returned when user_ids narrows scope.
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={
+                    "user_ids": "@inactive_user:my.domain.name",
+                    "inactive_days": "3650",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            # inactive_user logged in just now → last_login_ts > threshold (10y ago)
+            # so they should be EXCLUDED (not inactive enough)
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            self.assertNotIn("@inactive_user:my.domain.name", returned_ids)
+            self.assertEqual(data["totalDocs"], 0)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_inactive_days_never_active_included(self):
+        """Users with no login or message history are included with inactive_days."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="never_active",
+                password="pw1",
+                admin=False,
+            )
+            # Do NOT log in as never_active — no user_ips or events rows
+            _, admin_token = await self.login_user("admin", "adminpw")
+
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={
+                    "user_ids": "@never_active:my.domain.name",
+                    "inactive_days": "1",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            # last_login_ts=0 and last_message_ts=0 both pass the threshold → included
+            self.assertIn("@never_active:my.domain.name", returned_ids)
+            self.assertEqual(data["totalDocs"], 1)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_notification_cooldown_requires_bot_config(self):
+        """notification_cooldown_ms returns 400 when bot user ID is not configured."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+            # No user_activity_notification_bot_user_id in module config
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={"notification_cooldown_ms": "60000"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn(
+                "user_activity_notification_bot_user_id",
+                response.json().get("error", ""),
+            )
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_notification_cooldown_excludes_recently_notified(self):
+        """Users with a recent p.room.notice in their bot DM are excluded."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            bot_user_id = "@bot:my.domain.name"
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "user_activity_notification_bot_user_id": bot_user_id,
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="bot",
+                password="botpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="learner",
+                password="pw1",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+            _, bot_token = await self.login_user("bot", "botpw")
+            _, learner_token = await self.login_user("learner", "pw1")
+
+            # Create a DM room between bot and learner
+            dm_resp = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json={
+                    "preset": "trusted_private_chat",
+                    "is_direct": True,
+                    "invite": ["@learner:my.domain.name"],
+                },
+                headers={"Authorization": f"Bearer {bot_token}"},
+                timeout=30,
+            )
+            self.assertEqual(dm_resp.status_code, 200)
+            dm_room_id = dm_resp.json()["room_id"]
+
+            # Learner accepts invite
+            requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{dm_room_id}",
+                headers={"Authorization": f"Bearer {learner_token}"},
+                timeout=30,
+            )
+
+            # Set m.direct account data for learner so the filter can find the DM
+            requests.put(
+                f"{self.server_url}/_matrix/client/v3/user/@learner:my.domain.name/account_data/m.direct",
+                json={bot_user_id: [dm_room_id]},
+                headers={"Authorization": f"Bearer {learner_token}"},
+                timeout=30,
+            )
+
+            # Bot sends a p.room.notice in the DM (simulates a recent notification)
+            send_resp = requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{dm_room_id}"
+                f"/send/p.room.notice/txn-notice-1",
+                json={"body": "Hey there!"},
+                headers={"Authorization": f"Bearer {bot_token}"},
+                timeout=30,
+            )
+            self.assertEqual(send_resp.status_code, 200)
+
+            # Filter with a large cooldown — learner was just notified
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={
+                    "user_ids": "@learner:my.domain.name",
+                    "notification_cooldown_ms": str(24 * 60 * 60 * 1000),  # 1 day
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            self.assertNotIn("@learner:my.domain.name", returned_ids)
+            self.assertEqual(data["totalDocs"], 0)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_notification_cooldown_includes_expired(self):
+        """Users whose last bot notice is older than the cooldown are included."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            bot_user_id = "@bot:my.domain.name"
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "user_activity_notification_bot_user_id": bot_user_id,
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="admin",
+                password="adminpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="bot",
+                password="botpw",
+                admin=True,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="learner",
+                password="pw1",
+                admin=False,
+            )
+            _, admin_token = await self.login_user("admin", "adminpw")
+            _, bot_token = await self.login_user("bot", "botpw")
+            _, learner_token = await self.login_user("learner", "pw1")
+
+            # Create DM, learner joins
+            dm_resp = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                json={
+                    "preset": "trusted_private_chat",
+                    "is_direct": True,
+                    "invite": ["@learner:my.domain.name"],
+                },
+                headers={"Authorization": f"Bearer {bot_token}"},
+                timeout=30,
+            )
+            self.assertEqual(dm_resp.status_code, 200)
+            dm_room_id = dm_resp.json()["room_id"]
+            requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{dm_room_id}",
+                headers={"Authorization": f"Bearer {learner_token}"},
+                timeout=30,
+            )
+            requests.put(
+                f"{self.server_url}/_matrix/client/v3/user/@learner:my.domain.name/account_data/m.direct",
+                json={bot_user_id: [dm_room_id]},
+                headers={"Authorization": f"Bearer {learner_token}"},
+                timeout=30,
+            )
+
+            # Bot sends a p.room.notice in the DM
+            requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{dm_room_id}"
+                f"/send/p.room.notice/txn-notice-2",
+                json={"body": "Hey there!"},
+                headers={"Authorization": f"Bearer {bot_token}"},
+                timeout=30,
+            )
+
+            # Use a tiny cooldown (1ms) — the notice was sent >1ms ago
+            url = f"{self.server_url}/_synapse/client/pangea/v1/user_activity"
+            response = requests.get(
+                url,
+                params={
+                    "user_ids": "@learner:my.domain.name",
+                    "notification_cooldown_ms": "1",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            returned_ids = {u["user_id"] for u in data["docs"]}
+            self.assertIn("@learner:my.domain.name", returned_ids)
+            self.assertEqual(data["totalDocs"], 1)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )


### PR DESCRIPTION
## What

Add `user_ids`, `course_ids`, `inactive_days`, and `notification_cooldown_ms` as optional query params to `GET /_synapse/client/pangea/v1/user_activity`.

## Why

Closes #81

The bot's interactive restarter scans all users page-by-page and filters client-side, wasting O(total_users / page_size) requests when only a small subset is needed.

## Testing

- 7 new e2e test cases covering all filter combinations:
  - `test_user_ids_filter` — restricts docs and totalDocs to given user IDs
  - `test_course_ids_filter` — returns only course room members
  - `test_user_ids_course_ids_intersection` — intersection when both params given
  - `test_inactive_days_filter` — excludes recently-active users
  - `test_inactive_days_never_active_included` — zero-timestamp users included
  - `test_notification_cooldown_requires_bot_config` — 400 without config field
  - `test_notification_cooldown_excludes_recently_notified` — excludes notified users
  - `test_notification_cooldown_includes_expired` — includes users past cooldown

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

Operators using `notification_cooldown_ms` must add `user_activity_notification_bot_user_id: "@bot:your.server"` to the module config. No migration required — the field is optional and defaults to `null`; the param returns 400 without it.