### PR TITLE
feat(direct-message): grant both users admin power level in ensure_direct_message endpoint

### DIFF
--- a/synapse_pangea_chat/direct_message/ensure_direct_message.py
+++ b/synapse_pangea_chat/direct_message/ensure_direct_message.py
@@ -14,6 +14,7 @@ from synapse.api.errors import (
     InvalidClientCredentialsError,
     InvalidClientTokenError,
     MissingClientTokenError,
+    SynapseError,
 )
 from synapse.http import server
 from synapse.http.server import respond_with_json
@@ -99,6 +100,11 @@ class EnsureDirectMessage(Resource):
                     user_ids=canonical_user_ids,
                 )
 
+            power_levels_updated = await self._ensure_admin_power_levels(
+                user_ids=canonical_user_ids,
+                room_id=room_id,
+            )
+
             m_direct_updated_for: list[str] = []
             if await self._ensure_direct_entry(
                 canonical_user_ids[0], canonical_user_ids[1], room_id
@@ -117,6 +123,7 @@ class EnsureDirectMessage(Resource):
                     "created": created,
                     "reused": not created,
                     "m_direct_updated_for": m_direct_updated_for,
+                    "power_levels_updated": power_levels_updated,
                 },
                 send_cors=True,
             )
@@ -260,6 +267,12 @@ class EnsureDirectMessage(Resource):
                 "visibility": "private",
                 "invite": [user_ids[1]],
                 "is_direct": True,
+                "power_level_content_override": {
+                    "users": {
+                        user_ids[0]: 100,
+                        user_ids[1]: 100,
+                    }
+                },
             },
             ratelimit=False,
         )
@@ -312,6 +325,58 @@ class EnsureDirectMessage(Resource):
             action="join",
             ratelimit=False,
         )
+
+    async def _ensure_admin_power_levels(
+        self, user_ids: Sequence[str], room_id: str
+    ) -> bool:
+        """Ensure both users have power level 100 in the room.
+
+        Returns True if a power levels event was sent, False if no change was needed.
+        """
+        state = await self._api.get_room_state(
+            room_id, event_filter=[(EventTypes.PowerLevels, "")]
+        )
+        pl_event = state.get((EventTypes.PowerLevels, ""))
+        current_users: dict = {}
+        existing_content: dict = {}
+        if pl_event is not None:
+            existing_content = dict(pl_event.content)
+            current_users = dict(existing_content.get("users", {}))
+
+        if all(current_users.get(uid, 0) >= 100 for uid in user_ids):
+            return False
+
+        new_users = dict(current_users)
+        for uid in user_ids:
+            new_users[uid] = 100
+        new_content = dict(existing_content)
+        new_content["users"] = new_users
+
+        for sender in user_ids:
+            try:
+                await self._api.create_and_send_event_into_room(
+                    {
+                        "type": EventTypes.PowerLevels,
+                        "state_key": "",
+                        "room_id": room_id,
+                        "sender": sender,
+                        "content": new_content,
+                    }
+                )
+                return True
+            except SynapseError as e:
+                logger.warning(
+                    "Could not send power levels event as %s in room %s: %s",
+                    sender,
+                    room_id,
+                    e,
+                )
+
+        logger.warning(
+            "Failed to update power levels in room %s — neither user had sufficient PL",
+            room_id,
+        )
+        return False
 
     async def _ensure_direct_entry(
         self, user_id: str, counterpart_user_id: str, room_id: str

--- a/tests/test_direct_message_e2e.py
+++ b/tests/test_direct_message_e2e.py
@@ -226,3 +226,127 @@ class TestEnsureDirectMessageE2E(BaseSynapseE2ETest):
                 synapse_dir=synapse_dir,
                 postgres=postgres,
             )
+
+    async def test_creates_room_with_admin_power_levels(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            await self.register_user(config_path, synapse_dir, "bob", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            bob_user_id, _ = await self.login_user("bob", "pw")
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={"user_ids": [alice_user_id, bob_user_id]},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertTrue(data["created"])
+            # PLs are set at creation time via override — no separate PL event needed
+            self.assertFalse(data["power_levels_updated"])
+            room_id = data["room_id"]
+
+            pl_response = requests.get(
+                f"{self.server_url}/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels",
+                headers=self._headers(alice_token),
+            )
+            self.assertEqual(pl_response.status_code, 200)
+            users_pls = pl_response.json().get("users", {})
+            self.assertEqual(users_pls.get(alice_user_id), 100)
+            self.assertEqual(users_pls.get(bob_user_id), 100)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_reused_room_gets_admin_power_levels(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "admin", "pw", True)
+            await self.register_user(config_path, synapse_dir, "alice", "pw", False)
+            await self.register_user(config_path, synapse_dir, "bob", "pw", False)
+            _, admin_token = await self.login_user("admin", "pw")
+            alice_user_id, alice_token = await self.login_user("alice", "pw")
+            bob_user_id, bob_token = await self.login_user("bob", "pw")
+
+            # Alice creates the DM normally — she gets PL 100, bob stays at 0
+            create_room_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/createRoom",
+                headers=self._headers(alice_token),
+                json={
+                    "preset": "private_chat",
+                    "visibility": "private",
+                    "invite": [bob_user_id],
+                    "is_direct": True,
+                },
+            )
+            self.assertEqual(create_room_response.status_code, 200)
+            room_id = create_room_response.json()["room_id"]
+
+            join_response = requests.post(
+                f"{self.server_url}/_matrix/client/v3/join/{room_id}",
+                headers=self._headers(bob_token),
+            )
+            self.assertEqual(join_response.status_code, 200)
+
+            # Confirm bob is currently at default PL (not 100)
+            pl_before = requests.get(
+                f"{self.server_url}/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels",
+                headers=self._headers(alice_token),
+            )
+            self.assertEqual(pl_before.status_code, 200)
+            users_before = pl_before.json().get("users", {})
+            self.assertNotEqual(users_before.get(bob_user_id, 0), 100)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(admin_token),
+                json={"user_ids": [alice_user_id, bob_user_id]},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertFalse(data["created"])
+            self.assertTrue(data["reused"])
+            self.assertTrue(data["power_levels_updated"])
+
+            pl_after = requests.get(
+                f"{self.server_url}/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels",
+                headers=self._headers(alice_token),
+            )
+            self.assertEqual(pl_after.status_code, 200)
+            users_after = pl_after.json().get("users", {})
+            self.assertEqual(users_after.get(alice_user_id), 100)
+            self.assertEqual(users_after.get(bob_user_id), 100)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )


### PR DESCRIPTION
## What

Both users in a DM room (created or reused) via `POST /_synapse/client/pangea/v1/ensure_direct_message` now receive Matrix room power level 100.

## Why

Closes #82

## Testing

Automated — 2 new e2e tests added:
- `test_creates_room_with_admin_power_levels`: verifies new rooms have PL 100 for both users via `power_level_content_override` at creation
- `test_reused_room_gets_admin_power_levels`: verifies existing rooms with uneven PLs get patched to PL 100 for both users

All 6 tests in `tests.test_direct_message_e2e` pass.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None