### PR TITLE
fix(user_activity): wire user_activity_notification_bot_user_id into parse_config

### DIFF
--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -274,6 +274,18 @@ class PangeaChat:
         user_activity_burst_duration_seconds = config.get(
             "user_activity_burst_duration_seconds", 60
         )
+        user_activity_notification_bot_user_id = config.get(
+            "user_activity_notification_bot_user_id"
+        )
+        if user_activity_notification_bot_user_id is not None:
+            if not isinstance(user_activity_notification_bot_user_id, str):
+                raise ValueError(
+                    'Config "user_activity_notification_bot_user_id" must be a string'
+                )
+            if not user_activity_notification_bot_user_id.strip():
+                raise ValueError(
+                    'Config "user_activity_notification_bot_user_id" must not be empty'
+                )
 
         # --- delete_user config ---
         delete_user_requests_per_burst = config.get("delete_user_requests_per_burst", 5)
@@ -419,6 +431,7 @@ class PangeaChat:
             delete_room_burst_duration_seconds=delete_room_burst_duration_seconds,
             user_activity_requests_per_burst=user_activity_requests_per_burst,
             user_activity_burst_duration_seconds=user_activity_burst_duration_seconds,
+            user_activity_notification_bot_user_id=user_activity_notification_bot_user_id,
             delete_user_requests_per_burst=delete_user_requests_per_burst,
             delete_user_burst_duration_seconds=delete_user_burst_duration_seconds,
             delete_user_schedule_delay_seconds=delete_user_schedule_delay_seconds,

--- a/tests/test_user_activity_config.py
+++ b/tests/test_user_activity_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unittest
+
+from synapse_pangea_chat import PangeaChat
+
+_BASE_CONFIG = {
+    "cms_base_url": "http://cms.example.test",
+    "cms_service_api_key": "test-api-key",
+}
+
+
+class TestUserActivityConfig(unittest.TestCase):
+    def test_parse_config_includes_user_activity_notification_bot_user_id(self):
+        config = PangeaChat.parse_config(
+            {
+                **_BASE_CONFIG,
+                "user_activity_notification_bot_user_id": "@bot:example.com",
+            }
+        )
+        self.assertEqual(
+            config.user_activity_notification_bot_user_id, "@bot:example.com"
+        )
+
+    def test_parse_config_user_activity_notification_bot_user_id_defaults_to_none(
+        self,
+    ):
+        config = PangeaChat.parse_config({**_BASE_CONFIG})
+        self.assertIsNone(config.user_activity_notification_bot_user_id)
+
+    def test_parse_config_rejects_empty_user_activity_notification_bot_user_id(self):
+        with self.assertRaisesRegex(
+            ValueError, "user_activity_notification_bot_user_id"
+        ):
+            PangeaChat.parse_config(
+                {
+                    **_BASE_CONFIG,
+                    "user_activity_notification_bot_user_id": "",
+                }
+            )


### PR DESCRIPTION
## What

Wire `user_activity_notification_bot_user_id` into `parse_config` so the field is read from the config dict and passed to `PangeaChatConfig(...)`.

## Why

Closes #85

## Testing

Added 3 unit tests in `tests/test_user_activity_config.py`:
- `test_parse_config_includes_user_activity_notification_bot_user_id` — value is stored
- `test_parse_config_user_activity_notification_bot_user_id_defaults_to_none` — omitting defaults to `None`
- `test_parse_config_rejects_empty_user_activity_notification_bot_user_id` — empty string raises `ValueError`

All pass. No client testing needed — server-side config parsing only.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None