### PR TITLE
feat(grant-instructor-analytics-access): add endpoint

### DIFF
--- a/.github/instructions/grant-instructor-analytics-access.instructions.md
+++ b/.github/instructions/grant-instructor-analytics-access.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: "synapse_pangea_chat/grant_instructor_analytics_access/**,synapse_pangea_chat/__init__.py,tests/test_grant_instructor_analytics_access_e2e.py"
+---
+
+# Grant Instructor Analytics Access — Synapse Module
+
+Server-side endpoint that admin-force-joins a course's instructors into a student's analytics room, gated on the course having **Require analytics access to join** enabled. Triggered by the student's client when they join a toggle-on course or create a new analytics room inside one.
+
+Cross-repo design: [course-analytics-access.instructions.md](../../../.github/.github/instructions/course-analytics-access.instructions.md).
+
+## Endpoint
+
+`POST /_synapse/client/pangea/v1/grant_instructor_analytics_access`
+
+Lives in the `grant_instructor_analytics_access/` sub-package.
+
+## Contract
+
+- **Auth**: Matrix access token of the student (caller).
+- **Request**: `{ "course_id": "!course:example.com", "room_id": "!analytics:example.com" }`
+- **Validation**:
+  - `course_id` and `room_id` must be valid Matrix room IDs.
+  - Caller must be a joined member of `course_id` (403 otherwise).
+  - Course's `pangea.course_settings` state event (state_key `""`) must have `require_analytics_access: true` (403 otherwise).
+  - Target room's `m.room.create` content must have `type: "p.analytics"` (403 otherwise).
+  - Caller must be the analytics room creator — the `m.room.create` sender (403 otherwise).
+
+## Behavior
+
+- Reads the course room's joined-member list, computes effective power level for each (creator → 100 when MSC4289 is on, else `users[user_id]`, else `users_default`), and selects all local non-bot members whose effective power level is **strictly greater** than the caller's. Among those, only the highest-power-level cohort is granted.
+- For each instructor in the resulting set, performs an admin force-join into the analytics room. If the instructor is already joined, the action is `already_joined` and no event is generated. Otherwise the caller (who is the analytics room creator and therefore has invite power) is used as the inviter, then the instructor's own user is used as the sender of the join event.
+- Bot accounts are filtered by user ID pattern: `@bot:*`, `@bot-*:*`, `@*-bot:*`.
+- Federated target users are not supported — `is_mine` filters out non-local users from the candidate set.
+- Partial success is part of the contract. One instructor's failure does not prevent attempts for the remaining instructors.
+
+## Per-Instructor Results
+
+- `instructors_joined`: list of `{ user_id, action }` where `action` is one of `joined`, `already_joined`.
+- `errors`: list of `{ user_id, error }` for instructors whose join attempt raised.
+
+A course with no candidate instructors (e.g., the caller is the highest-PL human) returns an empty `instructors_joined` and empty `errors` — not an error condition.
+
+## Non-Goals
+
+- Discovering analytics rooms server-side. The client passes the `room_id` it just created or detected; the server validates and grants.
+- Language matching. The client decides which analytics room corresponds to the course's target language.
+- Server-side toggle CRUD. The client writes the `pangea.course_settings` state event directly with normal room-power-level checks.
+- Retroactive grants for students who joined before the toggle was flipped on. The pangea-bot operator script `run_grant_instructor_analytics_access.py` remains the manual escape hatch for that case.
+
+## Future Work
+
+_Last updated: 2026-04-30_
+
+- Client integration: [pangeachat/client#6065](https://github.com/pangeachat/client/issues/6065)

--- a/.github/instructions/grant-instructor-analytics-access.instructions.md
+++ b/.github/instructions/grant-instructor-analytics-access.instructions.md
@@ -17,18 +17,18 @@ Lives in the `grant_instructor_analytics_access/` sub-package.
 ## Contract
 
 - **Auth**: Matrix access token of the student (caller).
-- **Request**: `{ "course_id": "!course:example.com", "room_id": "!analytics:example.com" }`
+- **Request**: `{ "mx_course_id": "!course:example.com", "mx_analytics_room_id": "!analytics:example.com" }`. Both fields are Matrix room IDs (the `mx_` prefix disambiguates them from CMS course-plan UUIDs).
 - **Validation**:
-  - `course_id` and `room_id` must be valid Matrix room IDs.
-  - Caller must be a joined member of `course_id` (403 otherwise).
+  - `mx_course_id` and `mx_analytics_room_id` must be valid Matrix room IDs.
+  - Caller must be a joined member of `mx_course_id` (403 otherwise).
   - Course's `pangea.course_settings` state event (state_key `""`) must have `require_analytics_access: true` (403 otherwise).
-  - Target room's `m.room.create` content must have `type: "p.analytics"` (403 otherwise).
+  - `mx_analytics_room_id`'s `m.room.create` content must have `type: "p.analytics"` (403 otherwise).
   - Caller must be the analytics room creator — the `m.room.create` sender (403 otherwise).
 
 ## Behavior
 
 - Reads the course room's joined-member list, computes effective power level for each (creator → 100 when MSC4289 is on, else `users[user_id]`, else `users_default`), and selects all local non-bot members whose effective power level is **strictly greater** than the caller's. Among those, only the highest-power-level cohort is granted.
-- For each instructor in the resulting set, performs an admin force-join into the analytics room. If the instructor is already joined, the action is `already_joined` and no event is generated. Otherwise the caller (who is the analytics room creator and therefore has invite power) is used as the inviter, then the instructor's own user is used as the sender of the join event.
+- For each instructor in the resulting set, performs an admin force-join into `mx_analytics_room_id`. If the instructor is already joined, the action is `already_joined` and no event is generated. Otherwise the caller (who is the analytics room creator and therefore has invite power) is used as the inviter, then the instructor's own user is used as the sender of the join event.
 - Bot accounts are filtered by user ID pattern: `@bot:*`, `@bot-*:*`, `@*-bot:*`.
 - Federated target users are not supported — `is_mine` filters out non-local users from the candidate set.
 - Partial success is part of the contract. One instructor's failure does not prevent attempts for the remaining instructors.
@@ -42,7 +42,7 @@ A course with no candidate instructors (e.g., the caller is the highest-PL human
 
 ## Non-Goals
 
-- Discovering analytics rooms server-side. The client passes the `room_id` it just created or detected; the server validates and grants.
+- Discovering analytics rooms server-side. The client passes the `mx_analytics_room_id` it just created or detected; the server validates and grants.
 - Language matching. The client decides which analytics room corresponds to the course's target language.
 - Server-side toggle CRUD. The client writes the `pangea.course_settings` state event directly with normal room-power-level checks.
 - Retroactive grants for students who joined before the toggle was flipped on. The pangea-bot operator script `run_grant_instructor_analytics_access.py` remains the manual escape hatch for that case.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -29,6 +29,36 @@ python -m unittest discover -s tests -p 'test_*.py'
 python -m unittest tests.staging_tests.staging_tests
 ```
 
+## Local Setup (macOS arm64)
+
+Integration tests need PostgreSQL, OpenSSL, libpq, Rust (matrix-synapse 1.124.0 has no arm64 macOS wheel — pip builds it from sdist), and a Python with prebuilt synapse-extension wheels. Concrete recipe:
+
+```bash
+# One-time toolchain installs
+brew install postgresql@17 libpq openssl@3 rust python@3.13
+
+# Per-checkout: create venv with python@3.13 and install dev deps
+python3.13 -m venv .venv
+PATH="/opt/homebrew/opt/postgresql@17/bin:/opt/homebrew/opt/libpq/bin:$PATH" \
+LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib -L/opt/homebrew/opt/libpq/lib" \
+CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include -I/opt/homebrew/opt/libpq/include" \
+.venv/bin/pip install -e ".[dev]"
+.venv/bin/pip install "setuptools<81"   # synapse 1.124.0 still imports pkg_resources
+
+# Run tests (postgres@17 + UTF-8 locale required at run time, not just install time)
+PATH="/opt/homebrew/opt/postgresql@17/bin:/opt/homebrew/opt/libpq/bin:$PATH" \
+LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+.venv/bin/python -m unittest discover -s tests -p 'test_*.py'
+```
+
+Why each piece:
+
+- **`postgresql@17` before `libpq` on PATH** — both ship `initdb`, but `testing.postgresql` needs the one with `postgres` (the server binary) next to it; libpq's `initdb` is client-only.
+- **`LC_ALL=en_US.UTF-8` at run time** — Postgres 17 on macOS exits with `postmaster became multithreaded during startup` if `LC_ALL` is unset, but `LC_ALL=C` produces `SQL_ASCII` databases that synapse rejects with `IncorrectDatabaseSetup`. UTF-8 is the only locale that satisfies both.
+- **`setuptools<81`** — synapse 1.124.0 imports `pkg_resources`, which setuptools 81+ no longer ships by default.
+- **Rust** — matrix-synapse's PyPI release for 1.124.0 has no arm64 macOS wheel, so pip falls back to the sdist, which compiles the `synapse_rust` crate via `setuptools-rust`.
+- **Python 3.13, not 3.14** — synapse-extension wheels for 1.124.0 don't cover cp314 yet; using `python@3.13` lets the install succeed without rebuilding everything from source.
+
 ## CI
 
 Code style is enforced via `tox -e check_codestyle` (black + ruff). Tests are run locally — no GitHub Actions test workflow.

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -12,6 +12,9 @@ from synapse_pangea_chat.direct_message import EnsureDirectMessage
 from synapse_pangea_chat.direct_push import DirectPush
 from synapse_pangea_chat.email_invite import CreateCourseSpace, InviteByEmail
 from synapse_pangea_chat.export_user_data import ExportUserData
+from synapse_pangea_chat.grant_instructor_analytics_access import (
+    GrantInstructorAnalyticsAccess,
+)
 from synapse_pangea_chat.limit_user_directory import LimitUserDirectory
 from synapse_pangea_chat.public_courses import PublicCourses
 from synapse_pangea_chat.register_email import RegisterEmailRequestToken
@@ -150,6 +153,15 @@ class PangeaChat:
         self._api.register_web_resource(
             path="/_synapse/client/pangea/v1/assign_room_membership",
             resource=self.assign_room_membership_resource,
+        )
+
+        # --- Grant Instructor Analytics Access ---
+        self.grant_instructor_analytics_access_resource = (
+            GrantInstructorAnalyticsAccess(api, config)
+        )
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/grant_instructor_analytics_access",
+            resource=self.grant_instructor_analytics_access_resource,
         )
 
         # --- Direct Message ---

--- a/synapse_pangea_chat/grant_instructor_analytics_access/__init__.py
+++ b/synapse_pangea_chat/grant_instructor_analytics_access/__init__.py
@@ -1,0 +1,5 @@
+from synapse_pangea_chat.grant_instructor_analytics_access.grant_instructor_analytics_access import (
+    GrantInstructorAnalyticsAccess,
+)
+
+__all__ = ["GrantInstructorAnalyticsAccess"]

--- a/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
+++ b/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from synapse.api.constants import EventTypes
+from synapse.api.errors import (
+    AuthError,
+    InvalidClientCredentialsError,
+    InvalidClientTokenError,
+    MissingClientTokenError,
+)
+from synapse.http import server
+from synapse.http.server import respond_with_json
+from synapse.http.site import SynapseRequest
+from synapse.module_api import ModuleApi
+from synapse.types import RoomID
+from twisted.internet import defer
+from twisted.web.resource import Resource
+
+from synapse_pangea_chat.room_code.extract_body_json import extract_body_json
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger(
+    "synapse.module.synapse_pangea_chat.grant_instructor_analytics_access.grant_instructor_analytics_access"
+)
+
+MEMBERSHIP_INVITE = "invite"
+MEMBERSHIP_JOIN = "join"
+
+COURSE_SETTINGS_STATE_EVENT_TYPE = "pangea.course_settings"
+REQUIRE_ANALYTICS_ACCESS_KEY = "require_analytics_access"
+ANALYTICS_ROOM_TYPE = "p.analytics"
+
+
+def _is_probable_bot_user_id(user_id: str) -> bool:
+    if not user_id.startswith("@") or ":" not in user_id:
+        return False
+    localpart = user_id[1:].split(":", 1)[0]
+    return (
+        localpart == "bot" or localpart.startswith("bot-") or localpart.endswith("-bot")
+    )
+
+
+class GrantInstructorAnalyticsAccess(Resource):
+    isLeaf = True
+
+    def __init__(self, api: ModuleApi, config: PangeaChatConfig):
+        super().__init__()
+        self._api = api
+        self._config = config
+        self._auth = self._api._hs.get_auth()
+        self._datastores = self._api._hs.get_datastores()
+        self._storage_controllers = self._api._hs.get_storage_controllers()
+
+    def render_POST(self, request: SynapseRequest):
+        defer.ensureDeferred(self._async_render_POST(request))
+        return server.NOT_DONE_YET
+
+    async def _async_render_POST(self, request: SynapseRequest):
+        try:
+            requester = await self._auth.get_user_by_req(request)
+            requester_id = requester.user.to_string()
+
+            body = await extract_body_json(request)
+            if not isinstance(body, dict):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "Request body must be a JSON object"},
+                    send_cors=True,
+                )
+                return
+
+            course_id = body.get("course_id")
+            if not isinstance(course_id, str) or not self._is_valid_room_id(course_id):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "'course_id' must be a valid room ID"},
+                    send_cors=True,
+                )
+                return
+
+            room_id = body.get("room_id")
+            if not isinstance(room_id, str) or not self._is_valid_room_id(room_id):
+                respond_with_json(
+                    request,
+                    400,
+                    {"error": "'room_id' must be a valid room ID"},
+                    send_cors=True,
+                )
+                return
+
+            (
+                caller_membership,
+                _,
+            ) = await self._datastores.main.get_local_current_membership_for_user_in_room(
+                requester_id, course_id
+            )
+            if caller_membership != MEMBERSHIP_JOIN:
+                respond_with_json(
+                    request,
+                    403,
+                    {"error": "Caller is not a joined member of course_id"},
+                    send_cors=True,
+                )
+                return
+
+            settings_event = (
+                await self._storage_controllers.state.get_current_state_event(
+                    course_id, COURSE_SETTINGS_STATE_EVENT_TYPE, ""
+                )
+            )
+            if (
+                settings_event is None
+                or settings_event.content.get(REQUIRE_ANALYTICS_ACCESS_KEY) is not True
+            ):
+                respond_with_json(
+                    request,
+                    403,
+                    {"error": "Course does not require analytics access"},
+                    send_cors=True,
+                )
+                return
+
+            target_create_event = (
+                await self._storage_controllers.state.get_current_state_event(
+                    room_id, EventTypes.Create, ""
+                )
+            )
+            if target_create_event is None:
+                respond_with_json(
+                    request, 404, {"error": "Target room not found"}, send_cors=True
+                )
+                return
+
+            if target_create_event.content.get("type") != ANALYTICS_ROOM_TYPE:
+                respond_with_json(
+                    request,
+                    403,
+                    {"error": "Target room is not an analytics room"},
+                    send_cors=True,
+                )
+                return
+
+            if target_create_event.sender != requester_id:
+                respond_with_json(
+                    request,
+                    403,
+                    {"error": "Caller did not create the analytics room"},
+                    send_cors=True,
+                )
+                return
+
+            instructor_ids = await self._get_course_instructor_ids(
+                course_id=course_id, caller_id=requester_id
+            )
+
+            instructors_joined: list[dict[str, Any]] = []
+            errors: list[dict[str, str]] = []
+            for instructor_id in instructor_ids:
+                try:
+                    action = await self._force_join_instructor(
+                        room_id=room_id,
+                        instructor_id=instructor_id,
+                        inviter_id=requester_id,
+                    )
+                    instructors_joined.append(
+                        {"user_id": instructor_id, "action": action}
+                    )
+                except Exception as e:
+                    logger.info(
+                        "Failed force-joining %s into %s: %s",
+                        instructor_id,
+                        room_id,
+                        e,
+                    )
+                    errors.append(
+                        {
+                            "user_id": instructor_id,
+                            "error": str(e) or "Force-join failed",
+                        }
+                    )
+
+            respond_with_json(
+                request,
+                200,
+                {
+                    "course_id": course_id,
+                    "room_id": room_id,
+                    "instructors_joined": instructors_joined,
+                    "errors": errors,
+                },
+                send_cors=True,
+            )
+        except (
+            MissingClientTokenError,
+            InvalidClientTokenError,
+            InvalidClientCredentialsError,
+            AuthError,
+        ) as e:
+            logger.info("Authentication failed: %s", e)
+            respond_with_json(
+                request,
+                401,
+                {"error": "Unauthorized", "errcode": "M_UNAUTHORIZED"},
+                send_cors=True,
+            )
+        except Exception:
+            logger.exception("Error granting instructor analytics access")
+            respond_with_json(
+                request, 500, {"error": "Internal server error"}, send_cors=True
+            )
+
+    def _is_valid_room_id(self, room_id: str) -> bool:
+        try:
+            RoomID.from_string(room_id)
+        except Exception:
+            return False
+        return True
+
+    async def _get_course_instructor_ids(
+        self, course_id: str, caller_id: str
+    ) -> list[str]:
+        room_state = await self._api.get_room_state(
+            room_id=course_id,
+            event_filter=[
+                (EventTypes.Create, ""),
+                (EventTypes.PowerLevels, ""),
+                (EventTypes.Member, None),
+            ],
+        )
+
+        create_event = room_state.get((EventTypes.Create, ""))
+        power_levels_event = room_state.get((EventTypes.PowerLevels, ""))
+
+        joined_members: set[str] = set()
+        for state_event in room_state.values():
+            if state_event.type != EventTypes.Member:
+                continue
+            if state_event.content.get("membership") != MEMBERSHIP_JOIN:
+                continue
+            user_id = state_event.state_key
+            if not isinstance(user_id, str):
+                continue
+            joined_members.add(user_id)
+
+        if not joined_members:
+            return []
+
+        users_default = 0
+        users_power_levels: dict[str, Any] = {}
+        creator_power_users: set[str] = set()
+
+        if power_levels_event is not None:
+            users_default = self._coerce_int(
+                power_levels_event.content.get("users_default"), 0
+            )
+            raw_users_power_levels = power_levels_event.content.get("users", {})
+            if isinstance(raw_users_power_levels, dict):
+                users_power_levels = dict(raw_users_power_levels)
+
+        if (
+            create_event is not None
+            and create_event.room_version.msc4289_creator_power_enabled
+        ):
+            creators = create_event.content.get("additional_creators", []) + [
+                create_event.sender
+            ]
+            for creator in creators:
+                if isinstance(creator, str) and creator in joined_members:
+                    creator_power_users.add(creator)
+
+        member_powers: dict[str, int] = {}
+        for member_id in joined_members:
+            if member_id in creator_power_users:
+                member_powers[member_id] = 100
+            elif member_id in users_power_levels:
+                member_powers[member_id] = self._coerce_int(
+                    users_power_levels[member_id], users_default
+                )
+            else:
+                member_powers[member_id] = users_default
+
+        caller_power = member_powers.get(caller_id, users_default)
+
+        candidates = [
+            (user_id, power)
+            for user_id, power in member_powers.items()
+            if power > caller_power
+            and user_id != caller_id
+            and self._api.is_mine(user_id)
+            and not _is_probable_bot_user_id(user_id)
+        ]
+        if not candidates:
+            return []
+
+        max_power = max(power for _, power in candidates)
+        return sorted(user_id for user_id, power in candidates if power == max_power)
+
+    async def _force_join_instructor(
+        self, room_id: str, instructor_id: str, inviter_id: str
+    ) -> str:
+        (
+            current_membership,
+            _,
+        ) = await self._datastores.main.get_local_current_membership_for_user_in_room(
+            instructor_id, room_id
+        )
+
+        if current_membership == MEMBERSHIP_JOIN:
+            return "already_joined"
+
+        if current_membership != MEMBERSHIP_INVITE:
+            await self._api.update_room_membership(
+                sender=inviter_id,
+                target=instructor_id,
+                room_id=room_id,
+                new_membership=MEMBERSHIP_INVITE,
+            )
+
+        await self._api.update_room_membership(
+            sender=instructor_id,
+            target=instructor_id,
+            room_id=room_id,
+            new_membership=MEMBERSHIP_JOIN,
+        )
+        return "joined"
+
+    def _coerce_int(self, value: Any, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default

--- a/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
+++ b/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
@@ -274,9 +274,8 @@ class GrantInstructorAnalyticsAccess(Resource):
             if isinstance(raw_users_power_levels, dict):
                 users_power_levels = dict(raw_users_power_levels)
 
-        if (
-            create_event is not None
-            and create_event.room_version.msc4289_creator_power_enabled
+        if create_event is not None and getattr(
+            create_event.room_version, "msc4289_creator_power_enabled", False
         ):
             creators = create_event.content.get("additional_creators", []) + [
                 create_event.sender

--- a/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
+++ b/synapse_pangea_chat/grant_instructor_analytics_access/grant_instructor_analytics_access.py
@@ -74,22 +74,30 @@ class GrantInstructorAnalyticsAccess(Resource):
                 )
                 return
 
-            course_id = body.get("course_id")
-            if not isinstance(course_id, str) or not self._is_valid_room_id(course_id):
+            mx_course_id = body.get("mx_course_id")
+            if not isinstance(mx_course_id, str) or not self._is_valid_room_id(
+                mx_course_id
+            ):
                 respond_with_json(
                     request,
                     400,
-                    {"error": "'course_id' must be a valid room ID"},
+                    {"error": "'mx_course_id' must be a valid Matrix room ID"},
                     send_cors=True,
                 )
                 return
 
-            room_id = body.get("room_id")
-            if not isinstance(room_id, str) or not self._is_valid_room_id(room_id):
+            mx_analytics_room_id = body.get("mx_analytics_room_id")
+            if not isinstance(mx_analytics_room_id, str) or not self._is_valid_room_id(
+                mx_analytics_room_id
+            ):
                 respond_with_json(
                     request,
                     400,
-                    {"error": "'room_id' must be a valid room ID"},
+                    {
+                        "error": (
+                            "'mx_analytics_room_id' must be a valid Matrix room ID"
+                        )
+                    },
                     send_cors=True,
                 )
                 return
@@ -98,20 +106,20 @@ class GrantInstructorAnalyticsAccess(Resource):
                 caller_membership,
                 _,
             ) = await self._datastores.main.get_local_current_membership_for_user_in_room(
-                requester_id, course_id
+                requester_id, mx_course_id
             )
             if caller_membership != MEMBERSHIP_JOIN:
                 respond_with_json(
                     request,
                     403,
-                    {"error": "Caller is not a joined member of course_id"},
+                    {"error": "Caller is not a joined member of mx_course_id"},
                     send_cors=True,
                 )
                 return
 
             settings_event = (
                 await self._storage_controllers.state.get_current_state_event(
-                    course_id, COURSE_SETTINGS_STATE_EVENT_TYPE, ""
+                    mx_course_id, COURSE_SETTINGS_STATE_EVENT_TYPE, ""
                 )
             )
             if (
@@ -128,12 +136,15 @@ class GrantInstructorAnalyticsAccess(Resource):
 
             target_create_event = (
                 await self._storage_controllers.state.get_current_state_event(
-                    room_id, EventTypes.Create, ""
+                    mx_analytics_room_id, EventTypes.Create, ""
                 )
             )
             if target_create_event is None:
                 respond_with_json(
-                    request, 404, {"error": "Target room not found"}, send_cors=True
+                    request,
+                    404,
+                    {"error": "Analytics room not found"},
+                    send_cors=True,
                 )
                 return
 
@@ -156,7 +167,7 @@ class GrantInstructorAnalyticsAccess(Resource):
                 return
 
             instructor_ids = await self._get_course_instructor_ids(
-                course_id=course_id, caller_id=requester_id
+                mx_course_id=mx_course_id, caller_id=requester_id
             )
 
             instructors_joined: list[dict[str, Any]] = []
@@ -164,7 +175,7 @@ class GrantInstructorAnalyticsAccess(Resource):
             for instructor_id in instructor_ids:
                 try:
                     action = await self._force_join_instructor(
-                        room_id=room_id,
+                        mx_analytics_room_id=mx_analytics_room_id,
                         instructor_id=instructor_id,
                         inviter_id=requester_id,
                     )
@@ -175,7 +186,7 @@ class GrantInstructorAnalyticsAccess(Resource):
                     logger.info(
                         "Failed force-joining %s into %s: %s",
                         instructor_id,
-                        room_id,
+                        mx_analytics_room_id,
                         e,
                     )
                     errors.append(
@@ -189,8 +200,8 @@ class GrantInstructorAnalyticsAccess(Resource):
                 request,
                 200,
                 {
-                    "course_id": course_id,
-                    "room_id": room_id,
+                    "mx_course_id": mx_course_id,
+                    "mx_analytics_room_id": mx_analytics_room_id,
                     "instructors_joined": instructors_joined,
                     "errors": errors,
                 },
@@ -223,10 +234,10 @@ class GrantInstructorAnalyticsAccess(Resource):
         return True
 
     async def _get_course_instructor_ids(
-        self, course_id: str, caller_id: str
+        self, mx_course_id: str, caller_id: str
     ) -> list[str]:
         room_state = await self._api.get_room_state(
-            room_id=course_id,
+            room_id=mx_course_id,
             event_filter=[
                 (EventTypes.Create, ""),
                 (EventTypes.PowerLevels, ""),
@@ -302,13 +313,13 @@ class GrantInstructorAnalyticsAccess(Resource):
         return sorted(user_id for user_id, power in candidates if power == max_power)
 
     async def _force_join_instructor(
-        self, room_id: str, instructor_id: str, inviter_id: str
+        self, mx_analytics_room_id: str, instructor_id: str, inviter_id: str
     ) -> str:
         (
             current_membership,
             _,
         ) = await self._datastores.main.get_local_current_membership_for_user_in_room(
-            instructor_id, room_id
+            instructor_id, mx_analytics_room_id
         )
 
         if current_membership == MEMBERSHIP_JOIN:
@@ -318,14 +329,14 @@ class GrantInstructorAnalyticsAccess(Resource):
             await self._api.update_room_membership(
                 sender=inviter_id,
                 target=instructor_id,
-                room_id=room_id,
+                room_id=mx_analytics_room_id,
                 new_membership=MEMBERSHIP_INVITE,
             )
 
         await self._api.update_room_membership(
             sender=instructor_id,
             target=instructor_id,
-            room_id=room_id,
+            room_id=mx_analytics_room_id,
             new_membership=MEMBERSHIP_JOIN,
         )
         return "joined"

--- a/tests/test_grant_instructor_analytics_access_e2e.py
+++ b/tests/test_grant_instructor_analytics_access_e2e.py
@@ -1,0 +1,498 @@
+from urllib.parse import quote
+
+import requests
+
+from .base_e2e import BaseSynapseE2ETest
+
+
+class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
+    def _endpoint(self) -> str:
+        return (
+            f"{self.server_url}"
+            f"/_synapse/client/pangea/v1/grant_instructor_analytics_access"
+        )
+
+    def _headers(self, access_token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    def _member_state_url(self, room_id: str, user_id: str) -> str:
+        room_id_path = quote(room_id, safe="")
+        user_id_path = quote(user_id, safe="")
+        return (
+            f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}"
+            f"/state/m.room.member/{user_id_path}"
+        )
+
+    def _create_room_url(self) -> str:
+        return f"{self.server_url}/_matrix/client/v3/createRoom"
+
+    def _state_url(self, room_id: str, event_type: str, state_key: str = "") -> str:
+        room_id_path = quote(room_id, safe="")
+        event_type_path = quote(event_type, safe="")
+        state_key_path = quote(state_key, safe="")
+        return (
+            f"{self.server_url}/_matrix/client/v3/rooms/{room_id_path}"
+            f"/state/{event_type_path}/{state_key_path}"
+        )
+
+    def _join_url(self, room_id: str) -> str:
+        room_id_path = quote(room_id, safe="")
+        return f"{self.server_url}/_matrix/client/v3/join/{room_id_path}"
+
+    async def _create_course_space(
+        self, instructor_token: str, *, require_analytics_access: bool
+    ) -> str:
+        response = requests.post(
+            self._create_room_url(),
+            headers=self._headers(instructor_token),
+            json={
+                "visibility": "public",
+                "preset": "public_chat",
+                "creation_content": {"type": "m.space"},
+                "initial_state": [
+                    {
+                        "type": "pangea.course_settings",
+                        "state_key": "",
+                        "content": {
+                            "require_analytics_access": require_analytics_access
+                        },
+                    }
+                ],
+                "name": "Test Course",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()["room_id"]
+
+    async def _create_analytics_room(self, student_token: str) -> str:
+        response = requests.post(
+            self._create_room_url(),
+            headers=self._headers(student_token),
+            json={
+                "visibility": "private",
+                "preset": "private_chat",
+                "creation_content": {
+                    "type": "p.analytics",
+                    "lang_code": "es",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()["room_id"]
+
+    async def _join_room(self, room_id: str, access_token: str) -> None:
+        response = requests.post(
+            self._join_url(room_id), headers=self._headers(access_token)
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    async def _set_user_power_level(
+        self, room_id: str, target_user_id: str, power_level: int, admin_token: str
+    ) -> None:
+        get_response = requests.get(
+            self._state_url(room_id, "m.room.power_levels"),
+            headers=self._headers(admin_token),
+        )
+        self.assertEqual(get_response.status_code, 200, get_response.text)
+        content = get_response.json()
+        users = dict(content.get("users", {}))
+        users[target_user_id] = power_level
+        content["users"] = users
+
+        put_response = requests.put(
+            self._state_url(room_id, "m.room.power_levels"),
+            headers=self._headers(admin_token),
+            json=content,
+        )
+        self.assertEqual(put_response.status_code, 200, put_response.text)
+
+    async def test_force_joins_instructor_when_toggle_on(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            teacher_user_id, teacher_token = await self.login_user("teacher", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            await self._join_room(course_id, student_token)
+            analytics_room_id = await self._create_analytics_room(student_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 200, response.text)
+            data = response.json()
+            self.assertEqual(data["course_id"], course_id)
+            self.assertEqual(data["room_id"], analytics_room_id)
+            self.assertEqual(
+                data["instructors_joined"],
+                [{"user_id": teacher_user_id, "action": "joined"}],
+            )
+            self.assertEqual(data["errors"], [])
+
+            membership = requests.get(
+                self._member_state_url(analytics_room_id, teacher_user_id),
+                headers=self._headers(student_token),
+            )
+            self.assertEqual(membership.status_code, 200, membership.text)
+            self.assertEqual(membership.json()["membership"], "join")
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_returns_already_joined_when_instructor_is_member(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            teacher_user_id, teacher_token = await self.login_user("teacher", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            await self._join_room(course_id, student_token)
+            analytics_room_id = await self._create_analytics_room(student_token)
+
+            first = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+            self.assertEqual(first.status_code, 200, first.text)
+            self.assertEqual(
+                first.json()["instructors_joined"],
+                [{"user_id": teacher_user_id, "action": "joined"}],
+            )
+
+            second = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+            self.assertEqual(second.status_code, 200, second.text)
+            self.assertEqual(
+                second.json()["instructors_joined"],
+                [{"user_id": teacher_user_id, "action": "already_joined"}],
+            )
+            self.assertEqual(second.json()["errors"], [])
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_403_when_caller_not_in_course(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            _, teacher_token = await self.login_user("teacher", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            # Student does NOT join the course.
+            analytics_room_id = await self._create_analytics_room(student_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 403, response.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_403_when_toggle_off(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            _, teacher_token = await self.login_user("teacher", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=False
+            )
+            await self._join_room(course_id, student_token)
+            analytics_room_id = await self._create_analytics_room(student_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 403, response.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_403_when_target_room_is_not_analytics(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            _, teacher_token = await self.login_user("teacher", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            await self._join_room(course_id, student_token)
+            non_analytics_room_id = await self.create_private_room(student_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": non_analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 403, response.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_403_when_caller_did_not_create_analytics_room(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "studentA", "pw", False)
+            await self.register_user(config_path, synapse_dir, "studentB", "pw", False)
+            _, teacher_token = await self.login_user("teacher", "pw")
+            _, student_a_token = await self.login_user("studentA", "pw")
+            _, student_b_token = await self.login_user("studentB", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            await self._join_room(course_id, student_a_token)
+            await self._join_room(course_id, student_b_token)
+
+            # Student A creates the analytics room; Student B tries to grant.
+            analytics_room_id = await self._create_analytics_room(student_a_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_b_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 403, response.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_grants_only_highest_power_level_cohort(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "teacher", "pw", False)
+            await self.register_user(config_path, synapse_dir, "ta", "pw", False)
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            teacher_user_id, teacher_token = await self.login_user("teacher", "pw")
+            ta_user_id, ta_token = await self.login_user("ta", "pw")
+            _, student_token = await self.login_user("student", "pw")
+
+            course_id = await self._create_course_space(
+                teacher_token, require_analytics_access=True
+            )
+            await self._join_room(course_id, ta_token)
+            await self._set_user_power_level(course_id, ta_user_id, 50, teacher_token)
+            await self._join_room(course_id, student_token)
+            analytics_room_id = await self._create_analytics_room(student_token)
+
+            response = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"course_id": course_id, "room_id": analytics_room_id},
+            )
+
+            self.assertEqual(response.status_code, 200, response.text)
+            joined = response.json()["instructors_joined"]
+            self.assertEqual(joined, [{"user_id": teacher_user_id, "action": "joined"}])
+
+            ta_membership = requests.get(
+                self._member_state_url(analytics_room_id, ta_user_id),
+                headers=self._headers(student_token),
+            )
+            # TA should NOT be a member — endpoint state lookup should 404.
+            self.assertEqual(ta_membership.status_code, 404, ta_membership.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_400_for_invalid_room_ids(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            await self.register_user(config_path, synapse_dir, "student", "pw", False)
+            _, student_token = await self.login_user("student", "pw")
+
+            missing_course = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={"room_id": "!something:my.domain.name"},
+            )
+            self.assertEqual(missing_course.status_code, 400, missing_course.text)
+
+            invalid_course = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={
+                    "course_id": "not-a-room-id",
+                    "room_id": "!something:my.domain.name",
+                },
+            )
+            self.assertEqual(invalid_course.status_code, 400, invalid_course.text)
+
+            invalid_room = requests.post(
+                self._endpoint(),
+                headers=self._headers(student_token),
+                json={
+                    "course_id": "!something:my.domain.name",
+                    "room_id": "not-a-room-id",
+                },
+            )
+            self.assertEqual(invalid_room.status_code, 400, invalid_room.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_401_when_unauthenticated(self):
+        (
+            postgres,
+            synapse_dir,
+            config_path,
+            server_process,
+            stdout_thread,
+            stderr_thread,
+        ) = await self.start_test_synapse()
+
+        try:
+            response = requests.post(
+                self._endpoint(),
+                json={
+                    "course_id": "!course:my.domain.name",
+                    "room_id": "!analytics:my.domain.name",
+                },
+            )
+            self.assertEqual(response.status_code, 401, response.text)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )

--- a/tests/test_grant_instructor_analytics_access_e2e.py
+++ b/tests/test_grant_instructor_analytics_access_e2e.py
@@ -131,13 +131,16 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 200, response.text)
             data = response.json()
-            self.assertEqual(data["course_id"], course_id)
-            self.assertEqual(data["room_id"], analytics_room_id)
+            self.assertEqual(data["mx_course_id"], course_id)
+            self.assertEqual(data["mx_analytics_room_id"], analytics_room_id)
             self.assertEqual(
                 data["instructors_joined"],
                 [{"user_id": teacher_user_id, "action": "joined"}],
@@ -184,7 +187,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             first = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
             self.assertEqual(first.status_code, 200, first.text)
             self.assertEqual(
@@ -195,7 +201,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             second = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
             self.assertEqual(second.status_code, 200, second.text)
             self.assertEqual(
@@ -237,7 +246,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 403, response.text)
@@ -275,7 +287,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 403, response.text)
@@ -313,7 +328,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": non_analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": non_analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 403, response.text)
@@ -356,7 +374,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_b_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 403, response.text)
@@ -398,7 +419,10 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"course_id": course_id, "room_id": analytics_room_id},
+                json={
+                    "mx_course_id": course_id,
+                    "mx_analytics_room_id": analytics_room_id,
+                },
             )
 
             self.assertEqual(response.status_code, 200, response.text)
@@ -437,7 +461,7 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             missing_course = requests.post(
                 self._endpoint(),
                 headers=self._headers(student_token),
-                json={"room_id": "!something:my.domain.name"},
+                json={"mx_analytics_room_id": "!something:my.domain.name"},
             )
             self.assertEqual(missing_course.status_code, 400, missing_course.text)
 
@@ -445,8 +469,8 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
                 self._endpoint(),
                 headers=self._headers(student_token),
                 json={
-                    "course_id": "not-a-room-id",
-                    "room_id": "!something:my.domain.name",
+                    "mx_course_id": "not-a-room-id",
+                    "mx_analytics_room_id": "!something:my.domain.name",
                 },
             )
             self.assertEqual(invalid_course.status_code, 400, invalid_course.text)
@@ -455,8 +479,8 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
                 self._endpoint(),
                 headers=self._headers(student_token),
                 json={
-                    "course_id": "!something:my.domain.name",
-                    "room_id": "not-a-room-id",
+                    "mx_course_id": "!something:my.domain.name",
+                    "mx_analytics_room_id": "not-a-room-id",
                 },
             )
             self.assertEqual(invalid_room.status_code, 400, invalid_room.text)
@@ -483,8 +507,8 @@ class TestGrantInstructorAnalyticsAccessE2E(BaseSynapseE2ETest):
             response = requests.post(
                 self._endpoint(),
                 json={
-                    "course_id": "!course:my.domain.name",
-                    "room_id": "!analytics:my.domain.name",
+                    "mx_course_id": "!course:my.domain.name",
+                    "mx_analytics_room_id": "!analytics:my.domain.name",
                 },
             )
             self.assertEqual(response.status_code, 401, response.text)


### PR DESCRIPTION
## What

Adds `POST /_synapse/client/pangea/v1/grant_instructor_analytics_access`. The student's client calls this when they join a course whose `pangea.course_settings.require_analytics_access` toggle is on, or when they create a new analytics room inside one. The endpoint admin-force-joins the course's instructor cohort into the student's analytics room.

## Why

Closes #87. Cross-repo design: [course-analytics-access.instructions.md](https://github.com/pangeachat/.github/blob/main/.github/instructions/course-analytics-access.instructions.md). Client work: [pangeachat/client#6065](https://github.com/pangeachat/client/issues/6065).

## Behavior

- Auth: student access token. Caller must be joined in `mx_course_id`, course toggle must be on, target room must be a `p.analytics` room created by the caller.
- Selects local non-bot members of the course whose effective power level is strictly greater than the caller's, then keeps only the highest-PL cohort.
- Force-joins each by issuing an invite from the caller (analytics room creator → has invite power) followed by a self-join from the instructor.
- Idempotent: already-joined instructors return `action: already_joined`. Errors are per-instructor; one failure does not block the rest.

## Testing

- **Lint**: black + ruff pass on the new files. (Pre-existing main lint failures in unrelated files are inherited but not introduced by this PR.)
- **E2E**: all 9 new tests pass locally against synapse 1.124.0 + postgres 17 (`testing.postgresql`-spawned). Coverage: happy path; idempotency (`already_joined`); 403s for caller-not-in-course / toggle-off / wrong room type / non-creator caller; PL-cohort filtering (TA at PL 50 not granted when teacher at PL 100 is present); 400s for invalid room IDs / missing fields; 401 unauthenticated.
- Per [testing.instructions.md](https://github.com/pangeachat/synapse-pangea-chat/blob/main/.github/instructions/testing.instructions.md), this repo runs e2e tests locally — there is no CI test workflow.

Caught and fixed during local e2e: synapse 1.124.0's `RoomVersion` has no `msc4289_creator_power_enabled` attribute, so the original copy from `assign_room_membership.py` raised `AttributeError` and 500'd. Now uses `getattr(..., False)` to tolerate older synapse builds (the existing `assign_room_membership` has the same latent issue but I left it alone — separate fix).

- [ ] Staging
- [ ] Production

## Deploy Notes

None — additive endpoint, no config or migrations. Client integration in client#6065 is gated behind the new course toggle (default off), so deploying this server change ahead of the client is safe.