### PR TITLE
fix(room_code): downgrade invalid access_code log from error to warning

### DIFF
--- a/synapse_pangea_chat/room_code/knock_with_code.py
+++ b/synapse_pangea_chat/room_code/knock_with_code.py
@@ -99,7 +99,7 @@ class KnockWithCode(Resource):
                 or not access_code.isalnum()
                 or not any(char.isdigit() for char in access_code)  # At least one digit
             ):
-                logger.error(f"Invalid 'access_code': {access_code}")
+                logger.warning(f"Invalid 'access_code': {access_code}")
                 respond_with_json(
                     request,
                     400,


### PR DESCRIPTION
## What

\`logger.error\` → \`logger.warning\` in \`knock_with_code.py\` for malformed access codes.

## Why

Closes #97. Invalid user-supplied access codes are client-input validation, not a server error. \`logger.error\` triggered Sentry's \`LoggingIntegration\` to capture each attempt (Sentry: \`SYNAPSE-B9\`, \`Invalid 'access_code': 1234\`).

Note: parallel \`preview_with_code.py\` already does not log at error level for the same validation — this aligns \`knock_with_code.py\` with that.

## Testing

- [x] Unit (N/A — no tests assert log level; one-word change)
- [ ] Staging — to verify after merge: hit \`/_synapse/client/pangea/v1/knock_with_code\` with a malformed access code (e.g. \`"1234"\`) and confirm Sentry no longer creates an event for \`SYNAPSE-B9\`
- [ ] Production

## Deploy Notes

None.