### PR TITLE
chore(deps): group dependabot PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Why

Dependabot has been filing one PR per package bump with no grouping. Most are minor/patch updates that can travel together safely.

Closes #99

Part of org-wide rollout; choreographer landed first at pangeachat/2-step-choreographer#2241.

## What

Adds a \`groups:\` block per ecosystem in \`.github/dependabot.yml\`:

- \`pip-minor-patch\` bundles all pip minor/patch bumps into one weekly PR
- \`actions-minor-patch\` same for github-actions

Majors stay ungrouped (one PR each) so they get individual review.

## Testing

- [x] Local: yaml syntax valid
- [ ] Staging: n/a (config-only change)
- [ ] Production: verified by next weekly Dependabot run producing grouped PRs