### PR TITLE
chore(room_code): link tracked improvement to private issue

### DIFF
--- a/synapse_pangea_chat/room_code/generate_room_code.py
+++ b/synapse_pangea_chat/room_code/generate_room_code.py
@@ -2,6 +2,7 @@ import random
 import string
 
 
+# Planned improvement tracked at pangeachat/security#73 (private).
 def generate_access_code() -> str:
     """Generate 7 character alphanumeric access code with at least one digit."""
 


### PR DESCRIPTION
Adds a single-line stub comment in `generate_access_code` pointing maintainers to the private tracker for the planned improvement. Keeps the public source honest about work-in-flight without revealing the technical detail behind it.

Refs pangeachat/.github#121 (cross-repo deploy-note).
Refs pangeachat/security#73 (private detail).

## Why now

Pre-publication audit for the AGPL public-release decision flagged this area as something to track explicitly so a maintainer touching it doesn't redundantly improve it (or accidentally regress it) before the coordinated cross-repo rollout lands.

## Why not just fix it here

The fix has cross-repo deploy ordering — client + CloudFront must ship `{7,N}` regex relaxes first, then ~1 week of mobile-client drain, then the server bump. See pangeachat/.github#121 for the full sequence.