### PR TITLE
chore(docs): dedupe Feature Docs index from copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,9 +15,3 @@ Single entry-point class `PangeaChat` (`synapse_pangea_chat/__init__.py`) compos
 - **Entry point**: `synapse_pangea_chat/__init__.py` — `PangeaChat` class, registers all resources & callbacks
 - **Config**: `synapse_pangea_chat/config.py` — `PangeaChatConfig` (attrs, all keys optional with defaults)
 - **Config parsing**: `PangeaChat.parse_config()` in `__init__.py`
-
-## Feature Docs
-
-- [assign-room-membership.instructions.md](instructions/assign-room-membership.instructions.md) — server-admin endpoint for assigning local users to rooms without caller membership
-- [direct-push.instructions.md](instructions/direct-push.instructions.md) — server-admin endpoint for roomless lower-level push delivery without Matrix event persistence
-- [ensure-direct-message.instructions.md](instructions/ensure-direct-message.instructions.md) — server-admin endpoint for creating or repairing 1:1 DMs and `m.direct`


### PR DESCRIPTION
## Why

The sync-copilot-to-claude script regenerates a Feature Docs index into the generated CLAUDE.md every session, reading filenames from `.github/instructions/` directly. A hand-written copy of the same list lived in `copilot-instructions.md`, producing duplicate content in Claude Code's startup context.

Copilot is unaffected: it discovers `.instructions.md` files via the `applyTo:` glob in their own frontmatter, not via this index.

## Companion PRs (same fix, other repos)

- pangeachat/.github#130
- pangeachat/2-step-choreographer#2379
- pangeachat/pangea-bot#1294
- pangeachat/synapse-pangea-chat#114