### PR TITLE
fix: use online presence for delayed push

### DIFF
--- a/.github/instructions/delayed-push.instructions.md
+++ b/.github/instructions/delayed-push.instructions.md
@@ -10,16 +10,16 @@ Delayed push is an optional Synapse-module-only policy for normal Matrix HTTP pu
 ## Contract
 
 - Applies only to normal Synapse `HttpPusher` notifications. DirectPush, email pushers, and badge-only receipt updates remain unchanged.
-- Uses Synapse's combined per-user `currently_active` presence signal. Online-but-not-currently-active, unavailable, offline, disabled presence, or presence lookup failure all send normally.
+- Uses Synapse's per-user presence state as `state == "online" OR currently_active == true`. Unavailable, offline with `currently_active == false`, disabled presence, or presence lookup failure all send normally.
 - Read wins over every other state: if Synapse no longer returns a deferred event as unread, no notification is sent.
-- Unread events for currently-active users defer at the configured interval until the user becomes inactive or the event reaches the configured max age.
+- Unread events for online-or-currently-active users defer at the configured interval until the user becomes inactive or the event reaches the configured max age.
 - The max delay clock is measured from the event origin timestamp, not from first deferral.
 - Deferral intentionally keeps the pusher cursor unchanged and accepts head-of-line blocking for that user's HTTP pusher/device. Other users and non-HTTP push paths are not blocked.
 - Fail open: delayed-push decision errors log and send normally.
 
 ## Synapse private API requirement
 
-This feature monkey-patches Synapse's private `HttpPusher` processing path. Keep it disabled by default and require an exact audited Synapse version when enabling it. Every Synapse upgrade must audit `synapse.push.httppusher.HttpPusher._unsafe_process`, `_start_processing`, pusher cursor advancement, and presence `currently_active` semantics before widening the allowed version.
+This feature monkey-patches Synapse's private `HttpPusher` processing path. Keep it disabled by default and require an exact audited Synapse version when enabling it. Every Synapse upgrade must audit `synapse.push.httppusher.HttpPusher._unsafe_process`, `_start_processing`, pusher cursor advancement, and presence `state`/`currently_active` semantics before widening the allowed version.
 
 ## Rollout
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Requester must be a Synapse server admin. The endpoint accepts exactly two disti
 
 Optionally delays normal Matrix HTTP push notifications while the target user is actively using Synapse. This is disabled by default because it monkey-patches Synapse's private `HttpPusher` internals and must be re-audited for every Synapse version upgrade.
 
-When enabled, normal HTTP pushers reschedule unread notifications for currently-active users at the configured delay interval. If the event is read before the next check, Synapse's unread push-action query drops it and no notification is sent. If the user becomes inactive or the event reaches `max_delay_ms` age, the pusher sends normally. DirectPush, email pushers, and badge-only receipt updates are unchanged.
+When enabled, normal HTTP pushers reschedule unread notifications for users whose Synapse presence state is `online` or `currently_active` at the configured delay interval. If the event is read before the next check, Synapse's unread push-action query drops it and no notification is sent. If the user becomes inactive or the event reaches `max_delay_ms` age, the pusher sends normally. DirectPush, email pushers, and badge-only receipt updates are unchanged.
 
 ### Config
 

--- a/synapse_pangea_chat/delayed_push/delayed_push.py
+++ b/synapse_pangea_chat/delayed_push/delayed_push.py
@@ -274,10 +274,10 @@ async def _should_defer_push_action(self: Any, push_action: Any) -> bool:
         _clear_delayed_push_state(self)
         return False
 
-    if not await _user_is_currently_active(self):
+    if not await _user_is_online_or_currently_active(self):
         logger.info(
             "Pangea delayed push sending event %s for user %s because user is not "
-            "currently active",
+            "online or currently active",
             push_action.event_id,
             self.user_id,
         )
@@ -296,7 +296,7 @@ async def _should_defer_push_action(self: Any, push_action: Any) -> bool:
     return True
 
 
-async def _user_is_currently_active(self: Any) -> bool:
+async def _user_is_online_or_currently_active(self: Any) -> bool:
     server_config = getattr(getattr(self.hs, "config", None), "server", None)
     if getattr(server_config, "presence_enabled", True) is False:
         return False
@@ -305,7 +305,9 @@ async def _user_is_currently_active(self: Any) -> bool:
 
     presence_handler = self.hs.get_presence_handler()
     state = await presence_handler.current_state_for_user(self.user_id)
-    return bool(getattr(state, "currently_active", False))
+    return getattr(state, "state", None) == "online" or bool(
+        getattr(state, "currently_active", False)
+    )
 
 
 def _schedule_delayed_push(

--- a/tests/test_delayed_push_unit.py
+++ b/tests/test_delayed_push_unit.py
@@ -56,12 +56,17 @@ class FakeReactor:
 
 
 class FakePresenceHandler:
-    def __init__(self, active: bool = True, error: Exception | None = None):
+    def __init__(
+        self,
+        active: bool = True,
+        state: str = "online",
+        error: Exception | None = None,
+    ):
         if error is not None:
             self.current_state_for_user = AsyncMock(side_effect=error)
         else:
             self.current_state_for_user = AsyncMock(
-                return_value=SimpleNamespace(currently_active=active)
+                return_value=SimpleNamespace(state=state, currently_active=active)
             )
 
 
@@ -70,6 +75,7 @@ class FakeHomeServer:
         self,
         *,
         active: bool = True,
+        presence_state: str | None = None,
         presence_enabled: bool = True,
         track_presence: bool = True,
         presence_error: Exception | None = None,
@@ -81,7 +87,13 @@ class FakeHomeServer:
             )
         )
         self.reactor = FakeReactor()
-        self.presence_handler = FakePresenceHandler(active, presence_error)
+        if presence_state is None:
+            presence_state = "online" if active else "offline"
+        self.presence_handler = FakePresenceHandler(
+            active,
+            presence_state,
+            presence_error,
+        )
 
     def get_reactor(self):
         return self.reactor
@@ -238,7 +250,43 @@ class TestDelayedPushHelpers(unittest.IsolatedAsyncioTestCase):
             pusher.clock.time_msec() + 60_000,
         )
 
-    async def test_unsafe_process_sends_when_user_is_inactive(self):
+    async def test_unsafe_process_defers_user_who_is_online_but_not_currently_active(
+        self,
+    ):
+        pusher = FakePusher(active=False, event_age_ms=1_000)
+        pusher.hs = FakeHomeServer(active=False, presence_state="online")
+
+        with patch(
+            "synapse_pangea_chat.delayed_push.delayed_push.httppusher.opentracing.start_active_span",
+            return_value=nullcontext(),
+        ):
+            await _pangea_delayed_push_unsafe_process(pusher)
+
+        self.assertEqual(pusher.last_stream_ordering, 1)
+        pusher._process_one.assert_not_awaited()
+        pusher.store.update_pusher_last_stream_ordering_and_success.assert_not_awaited()
+        self.assertEqual(len(pusher.hs.reactor.calls), 1)
+
+    async def test_unsafe_process_defers_user_who_is_offline_but_currently_active(
+        self,
+    ):
+        pusher = FakePusher(active=True, event_age_ms=1_000)
+        pusher.hs = FakeHomeServer(active=True, presence_state="offline")
+
+        with patch(
+            "synapse_pangea_chat.delayed_push.delayed_push.httppusher.opentracing.start_active_span",
+            return_value=nullcontext(),
+        ):
+            await _pangea_delayed_push_unsafe_process(pusher)
+
+        self.assertEqual(pusher.last_stream_ordering, 1)
+        pusher._process_one.assert_not_awaited()
+        pusher.store.update_pusher_last_stream_ordering_and_success.assert_not_awaited()
+        self.assertEqual(len(pusher.hs.reactor.calls), 1)
+
+    async def test_unsafe_process_sends_when_user_is_not_online_or_currently_active(
+        self,
+    ):
         pusher = FakePusher(active=False, event_age_ms=1_000)
 
         with patch(


### PR DESCRIPTION
## Summary
- treat a user as active for delayed_push when Synapse presence is `state == "online" OR currently_active == true`
- add unit coverage for online-but-not-currently-active and offline-but-currently-active users
- update delayed_push docs/README to match the policy

Closes #120

## Validation
- `PYENV_VERSION=system PYTHONPATH=$PWD ../116-delay-http-push-notifications-while-users-are-active/.venv/bin/python -m unittest tests.test_delayed_push_unit`
- `PYENV_VERSION=system PYTHONPATH=$PWD ../116-delay-http-push-notifications-while-users-are-active/.venv/bin/python -m unittest tests.test_delayed_push_unit tests.test_direct_push_unit`
- `PYENV_VERSION=system ../116-delay-http-push-notifications-while-users-are-active/.venv/bin/black --check synapse_pangea_chat tests/test_delayed_push_unit.py`
- `PYENV_VERSION=system ../116-delay-http-push-notifications-while-users-are-active/.venv/bin/ruff check synapse_pangea_chat tests/test_delayed_push_unit.py`
- `PYENV_VERSION=system PYTHONPATH=$PWD ../116-delay-http-push-notifications-while-users-are-active/.venv/bin/mypy synapse_pangea_chat/delayed_push/delayed_push.py tests/test_delayed_push_unit.py`
- `PYENV_VERSION=system python3 -m compileall -q synapse_pangea_chat tests/test_delayed_push_unit.py`
- `git diff --check`
