### PR TITLE
feat: sort user activity by latest activity

### DIFF
--- a/.github/instructions/user-activity.instructions.md
+++ b/.github/instructions/user-activity.instructions.md
@@ -14,7 +14,7 @@ Three Synapse module endpoints that power the re-engagement system. Called by th
 
 - **Auth:** Matrix bearer token, server admin required (403 if not admin)
 - **Rate limiting:** None (admin-only, no rate limiting)
-- **Query params:** `page` (int, default 1), `limit` (int, default 50, max 200)
+- **Query params:** `page` (int, default 1), `limit` (int, default 50, max 200), `sort_by` (`user_id`, `last_login_ts`, `last_message_ts`, or `latest_activity`; default `user_id`), `sort_order` (`asc` or `desc`; default `asc`)
 
 **Response:**
 
@@ -25,7 +25,8 @@ Three Synapse module endpoints that power the re-engagement system. Called by th
       "user_id": "@alice:example.com",
       "display_name": "Alice",
       "last_login_ts": 1700000000000,
-      "last_message_ts": 1700000000000
+      "last_message_ts": 1700000000000,
+      "latest_activity_ts": 1700000000000
     }
   ],
   "page": 1,
@@ -35,7 +36,7 @@ Three Synapse module endpoints that power the re-engagement system. Called by th
 }
 ```
 
-User docs contain only basic activity metadata. Course memberships are available via the `user_courses` endpoint below.
+User docs contain only basic activity metadata. `latest_activity_ts` is `max(last_login_ts, last_message_ts)`. Defaults preserve historical `user_id` ascending order; callers that need recently active users should request `sort_by=latest_activity&sort_order=desc` so sorting happens before pagination. Course memberships are available via the `user_courses` endpoint below.
 
 ### 2. User Courses (paginated)
 
@@ -124,8 +125,9 @@ Splitting into three endpoints lets the bot:
 ### Users queries (`get_users.py`)
 
 1. **Count** — Total active (non-deactivated, non-guest) users.
-2. **Users + last login** — CTE pre-aggregates `user_ips` then JOINs, `LIMIT/OFFSET` for pagination.
-3. **Last message per user** — `events` table scoped with `WHERE sender IN (...)`.
+2. **Users + last login** — CTE pre-aggregates `user_ips`, applies requested `sort_by`/`sort_order`, then `LIMIT/OFFSET` for pagination when message timestamps are not needed before pagination.
+3. **Last message per user** — `events` table is scoped with `WHERE sender IN (...)` for default/user-login ordering, or pre-aggregated before pagination when callers sort/filter by `last_message_ts` or `latest_activity`.
+4. **Latest activity** — `latest_activity_ts` is always returned as `max(last_login_ts, last_message_ts)`; `sort_by=latest_activity` sorts globally before pagination.
 
 ### User Courses queries (`get_user_courses.py`)
 

--- a/synapse_pangea_chat/user_activity/get_users.py
+++ b/synapse_pangea_chat/user_activity/get_users.py
@@ -10,6 +10,16 @@ from synapse.storage.databases.main.room import RoomStore
 
 logger = logging.getLogger("synapse_pangea_chat.user_activity.get_users")
 
+USER_ACTIVITY_SORT_BY_VALUES = {
+    "user_id",
+    "last_login_ts",
+    "last_message_ts",
+    "latest_activity",
+}
+USER_ACTIVITY_SORT_ORDER_VALUES = {"asc", "desc"}
+DEFAULT_USER_ACTIVITY_SORT_BY = "user_id"
+DEFAULT_USER_ACTIVITY_SORT_ORDER = "asc"
+
 
 async def get_users(
     room_store: RoomStore,
@@ -22,6 +32,8 @@ async def get_users(
     notification_cooldown_ms: Optional[int] = None,
     bot_user_id: Optional[str] = None,
     api: Optional[ModuleApi] = None,
+    sort_by: str = DEFAULT_USER_ACTIVITY_SORT_BY,
+    sort_order: str = DEFAULT_USER_ACTIVITY_SORT_ORDER,
 ) -> Dict[str, Any]:
     """Return paginated list of local users with basic activity metadata.
 
@@ -36,6 +48,10 @@ async def get_users(
                                WARNING: performs O(N candidates) account-data lookups
                                when no user_ids/course_ids narrow the set.
 
+    Sort params are opt-in and non-breaking. Defaults preserve the historical
+    user_id ascending order. latest_activity means max(last_login_ts,
+    last_message_ts).
+
     When user_ids and course_ids are both provided the result is their intersection.
 
     totalDocs and maxPage always reflect the fully-filtered count.
@@ -43,7 +59,7 @@ async def get_users(
     Response shape:
         {
             "docs": [ { user_id, display_name, last_login_ts,
-                        last_message_ts } , … ],
+                        last_message_ts, latest_activity_ts } , … ],
             "page": 1,
             "limit": 50,
             "totalDocs": 200,
@@ -52,6 +68,16 @@ async def get_users(
 
     Course memberships are available via the separate user_courses endpoint.
     """
+    sort_by = (
+        sort_by
+        if sort_by in USER_ACTIVITY_SORT_BY_VALUES
+        else DEFAULT_USER_ACTIVITY_SORT_BY
+    )
+    sort_order = (
+        sort_order
+        if sort_order in USER_ACTIVITY_SORT_ORDER_VALUES
+        else DEFAULT_USER_ACTIVITY_SORT_ORDER
+    )
 
     # ------------------------------------------------------------------
     # Step 1 — resolve id_filter from user_ids / course_ids
@@ -120,7 +146,7 @@ async def get_users(
 
     needs_inactive_ctes = inactivity_threshold_ms is not None
 
-    def _inactive_ctes() -> str:
+    def _activity_ctes() -> str:
         return """
     WITH last_logins AS (
         SELECT user_id, MAX(last_seen) AS last_login_ts
@@ -152,7 +178,7 @@ async def get_users(
 
         if needs_inactive_ctes:
             count_query = f"""
-            {_inactive_ctes()}
+            {_activity_ctes()}
             SELECT COUNT(*)
             FROM users u
             LEFT JOIN last_logins ll ON ll.user_id = u.name
@@ -178,25 +204,35 @@ async def get_users(
             page = max_page
         offset = (page - 1) * limit
 
-        if needs_inactive_ctes:
+        needs_message_before_pagination = needs_inactive_ctes or sort_by in {
+            "last_message_ts",
+            "latest_activity",
+        }
+
+        if needs_message_before_pagination:
             users_query = f"""
-            {_inactive_ctes()}
+            {_activity_ctes()}
             SELECT
                 u.name AS user_id,
                 p.displayname AS display_name,
                 COALESCE(ll.last_login_ts, 0) AS last_login_ts,
-                COALESCE(lm.last_message_ts, 0) AS last_message_ts
+                COALESCE(lm.last_message_ts, 0) AS last_message_ts,
+                GREATEST(
+                    COALESCE(ll.last_login_ts, 0),
+                    COALESCE(lm.last_message_ts, 0)
+                ) AS latest_activity_ts
             FROM users u
             LEFT JOIN profiles p ON p.full_user_id = u.name
             LEFT JOIN last_logins ll ON ll.user_id = u.name
             LEFT JOIN last_messages lm ON lm.sender = u.name
             WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
-            ORDER BY u.name
+            ORDER BY {_sql_order_by(sort_by, sort_order)}
             LIMIT ? OFFSET ?
             """
             user_rows = await room_store.db_pool.execute(
                 "get_users_page", users_query, *filter_args, limit, offset
             )
+            users = [_user_from_activity_row(row) for row in user_rows]
         else:
             users_query = f"""
             {_login_cte()}
@@ -208,67 +244,14 @@ async def get_users(
             LEFT JOIN profiles p ON p.full_user_id = u.name
             LEFT JOIN last_logins ll ON ll.user_id = u.name
             WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
-            ORDER BY u.name
+            ORDER BY {_sql_login_only_order_by(sort_by, sort_order)}
             LIMIT ? OFFSET ?
             """
             user_rows = await room_store.db_pool.execute(
                 "get_users_page", users_query, *filter_args, limit, offset
             )
-
-        if not user_rows:
-            return {
-                "docs": [],
-                "page": page,
-                "limit": limit,
-                "totalDocs": total_docs,
-                "maxPage": max_page,
-            }
-
-        users: List[Dict[str, Any]] = []
-        page_user_ids: List[str] = []
-
-        if needs_inactive_ctes:
-            for row in user_rows:
-                uid, display_name, last_login_ts, last_message_ts = row
-                users.append(
-                    {
-                        "user_id": uid,
-                        "display_name": display_name,
-                        "last_login_ts": last_login_ts or 0,
-                        "last_message_ts": last_message_ts or 0,
-                    }
-                )
-                page_user_ids.append(uid)
-        else:
-            for row in user_rows:
-                uid, display_name, last_login_ts = row
-                users.append(
-                    {
-                        "user_id": uid,
-                        "display_name": display_name,
-                        "last_login_ts": last_login_ts or 0,
-                        "last_message_ts": 0,
-                    }
-                )
-                page_user_ids.append(uid)
-
-            # Fetch last message ts separately (path A without inactive filter)
-            user_placeholders = ",".join(["?" for _ in page_user_ids])
-            last_message_query = f"""
-            SELECT e.sender, MAX(e.origin_server_ts) AS last_message_ts
-            FROM events e
-            WHERE e.type = 'm.room.message'
-              AND e.sender IN ({user_placeholders})
-            GROUP BY e.sender
-            """
-            message_rows = await room_store.db_pool.execute(
-                "get_users_last_message", last_message_query, *page_user_ids
-            )
-            users_by_id = {u["user_id"]: u for u in users}
-            for row in message_rows:
-                sender, last_message_ts = row
-                if sender in users_by_id:
-                    users_by_id[sender]["last_message_ts"] = last_message_ts or 0
+            users = [_user_from_login_row(row) for row in user_rows]
+            await _attach_page_last_messages(room_store, users)
 
         return {
             "docs": users,
@@ -281,37 +264,39 @@ async def get_users(
     # ------------------------------------------------------------------
     # Path B — notification_cooldown_ms: full-scan then per-user filter
     # ------------------------------------------------------------------
-    # 1. Fetch all matching candidate user IDs (SQL-filtered, no LIMIT)
+    # 1. Fetch all matching candidate user docs (SQL-filtered, no LIMIT)
     extra_where, filter_args = _build_extra_where()
 
-    if needs_inactive_ctes:
-        candidates_query = f"""
-        {_inactive_ctes()}
-        SELECT u.name
-        FROM users u
-        LEFT JOIN last_logins ll ON ll.user_id = u.name
-        LEFT JOIN last_messages lm ON lm.sender = u.name
-        WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
-        ORDER BY u.name
-        """
-    else:
-        candidates_query = f"""
-        SELECT u.name
-        FROM users u
-        WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
-        ORDER BY u.name
-        """
+    candidates_query = f"""
+    {_activity_ctes()}
+    SELECT
+        u.name AS user_id,
+        p.displayname AS display_name,
+        COALESCE(ll.last_login_ts, 0) AS last_login_ts,
+        COALESCE(lm.last_message_ts, 0) AS last_message_ts,
+        GREATEST(
+            COALESCE(ll.last_login_ts, 0),
+            COALESCE(lm.last_message_ts, 0)
+        ) AS latest_activity_ts
+    FROM users u
+    LEFT JOIN profiles p ON p.full_user_id = u.name
+    LEFT JOIN last_logins ll ON ll.user_id = u.name
+    LEFT JOIN last_messages lm ON lm.sender = u.name
+    WHERE u.deactivated = 0 AND u.is_guest = 0{extra_where}
+    ORDER BY {_sql_order_by(sort_by, sort_order)}
+    """
 
     candidate_rows = await room_store.db_pool.execute(
         "get_users_candidates", candidates_query, *filter_args
     )
-    candidate_ids: List[str] = [row[0] for row in candidate_rows]
+    candidate_users = [_user_from_activity_row(row) for row in candidate_rows]
 
     # 2. Filter by notification cooldown
     cooldown_threshold_ms = int(time.time() * 1000) - notification_cooldown_ms
-    filtered_ids: List[str] = []
+    filtered_users: List[Dict[str, Any]] = []
 
-    for uid in candidate_ids:
+    for user in candidate_users:
+        uid = user["user_id"]
         recently_notified = await _user_recently_notified(
             room_store=room_store,
             api=api,
@@ -320,76 +305,26 @@ async def get_users(
             cooldown_threshold_ms=cooldown_threshold_ms,
         )
         if not recently_notified:
-            filtered_ids.append(uid)
+            filtered_users.append(user)
+
+    filtered_users = _sort_user_docs(
+        filtered_users,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
 
     # 3. Paginate in Python now that we have the exact filtered list
-    total_docs = len(filtered_ids)
+    total_docs = len(filtered_users)
     max_page = max(1, math.ceil(total_docs / limit))
     if page < 1:
         page = 1
     if page > max_page:
         page = max_page
 
-    page_ids = filtered_ids[(page - 1) * limit : page * limit]
-
-    if not page_ids:
-        return {
-            "docs": [],
-            "page": page,
-            "limit": limit,
-            "totalDocs": total_docs,
-            "maxPage": max_page,
-        }
-
-    # 4. Fetch display_name + last_login_ts + last_message_ts for page_ids
-    page_placeholders = ",".join(["?" for _ in page_ids])
-    page_users_query = f"""
-    {_login_cte()}
-    SELECT
-        u.name AS user_id,
-        p.displayname AS display_name,
-        COALESCE(ll.last_login_ts, 0) AS last_login_ts
-    FROM users u
-    LEFT JOIN profiles p ON p.full_user_id = u.name
-    LEFT JOIN last_logins ll ON ll.user_id = u.name
-    WHERE u.name IN ({page_placeholders})
-    ORDER BY u.name
-    """
-    page_user_rows = await room_store.db_pool.execute(
-        "get_users_page_b", page_users_query, *page_ids
-    )
-
-    users = []
-    for row in page_user_rows:
-        uid, display_name, last_login_ts = row
-        users.append(
-            {
-                "user_id": uid,
-                "display_name": display_name,
-                "last_login_ts": last_login_ts or 0,
-                "last_message_ts": 0,
-            }
-        )
-
-    # Fetch last message ts
-    last_message_query = f"""
-    SELECT e.sender, MAX(e.origin_server_ts) AS last_message_ts
-    FROM events e
-    WHERE e.type = 'm.room.message'
-      AND e.sender IN ({page_placeholders})
-    GROUP BY e.sender
-    """
-    message_rows = await room_store.db_pool.execute(
-        "get_users_last_message_b", last_message_query, *page_ids
-    )
-    users_by_id = {u["user_id"]: u for u in users}
-    for row in message_rows:
-        sender, last_message_ts = row
-        if sender in users_by_id:
-            users_by_id[sender]["last_message_ts"] = last_message_ts or 0
+    page_users = filtered_users[(page - 1) * limit : page * limit]
 
     return {
-        "docs": users,
+        "docs": page_users,
         "page": page,
         "limit": limit,
         "totalDocs": total_docs,
@@ -430,20 +365,134 @@ async def _user_recently_notified(
     if not bot_dm_rooms:
         return False
 
-    room_placeholders = ",".join(["?" for _ in bot_dm_rooms])
-    notice_query = f"""
-    SELECT 1 FROM events
-    WHERE room_id IN ({room_placeholders})
-      AND sender = ?
-      AND type = 'p.room.notice'
-      AND origin_server_ts > ?
-    LIMIT 1
+    placeholders = ",".join(["?" for _ in bot_dm_rooms])
+    query = f"""
+        SELECT 1
+        FROM events e
+        WHERE e.room_id IN ({placeholders})
+          AND e.sender = ?
+          AND e.type = 'p.room.notice'
+          AND e.origin_server_ts > ?
+        LIMIT 1
     """
-    notice_rows = await room_store.db_pool.execute(
-        "get_users_recent_notice",
-        notice_query,
+    rows = await room_store.db_pool.execute(
+        "get_users_recent_bot_notice",
+        query,
         *bot_dm_rooms,
         bot_user_id,
         cooldown_threshold_ms,
     )
-    return bool(notice_rows)
+    return bool(rows)
+
+
+def _sql_order_by(sort_by: str, sort_order: str) -> str:
+    direction = _sql_direction(sort_order)
+    if sort_by == "user_id":
+        return f"u.name {direction}"
+    if sort_by == "last_login_ts":
+        return f"COALESCE(ll.last_login_ts, 0) {direction}, u.name ASC"
+    if sort_by == "last_message_ts":
+        return f"COALESCE(lm.last_message_ts, 0) {direction}, u.name ASC"
+    if sort_by == "latest_activity":
+        return (
+            "GREATEST(COALESCE(ll.last_login_ts, 0), "
+            f"COALESCE(lm.last_message_ts, 0)) {direction}, u.name ASC"
+        )
+    raise ValueError(f"Unsupported user_activity sort_by: {sort_by}")
+
+
+def _sql_login_only_order_by(sort_by: str, sort_order: str) -> str:
+    direction = _sql_direction(sort_order)
+    if sort_by == "user_id":
+        return f"u.name {direction}"
+    if sort_by == "last_login_ts":
+        return f"COALESCE(ll.last_login_ts, 0) {direction}, u.name ASC"
+    raise ValueError(f"Unsupported login-only user_activity sort_by: {sort_by}")
+
+
+def _sql_direction(sort_order: str) -> str:
+    if sort_order == "asc":
+        return "ASC"
+    if sort_order == "desc":
+        return "DESC"
+    raise ValueError(f"Unsupported user_activity sort_order: {sort_order}")
+
+
+def _user_from_activity_row(row: Any) -> Dict[str, Any]:
+    uid, display_name, last_login_ts, last_message_ts, latest_activity_ts = row
+    return {
+        "user_id": uid,
+        "display_name": display_name,
+        "last_login_ts": last_login_ts or 0,
+        "last_message_ts": last_message_ts or 0,
+        "latest_activity_ts": latest_activity_ts or 0,
+    }
+
+
+def _user_from_login_row(row: Any) -> Dict[str, Any]:
+    uid, display_name, last_login_ts = row
+    return {
+        "user_id": uid,
+        "display_name": display_name,
+        "last_login_ts": last_login_ts or 0,
+        "last_message_ts": 0,
+        "latest_activity_ts": last_login_ts or 0,
+    }
+
+
+async def _attach_page_last_messages(
+    room_store: RoomStore,
+    users: List[Dict[str, Any]],
+) -> None:
+    if not users:
+        return
+
+    page_user_ids = [user["user_id"] for user in users]
+    user_placeholders = ",".join(["?" for _ in page_user_ids])
+    last_message_query = f"""
+    SELECT e.sender, MAX(e.origin_server_ts) AS last_message_ts
+    FROM events e
+    WHERE e.type = 'm.room.message'
+      AND e.sender IN ({user_placeholders})
+    GROUP BY e.sender
+    """
+    message_rows = await room_store.db_pool.execute(
+        "get_users_last_message", last_message_query, *page_user_ids
+    )
+    users_by_id = {u["user_id"]: u for u in users}
+    for row in message_rows:
+        sender, last_message_ts = row
+        if sender in users_by_id:
+            users_by_id[sender]["last_message_ts"] = last_message_ts or 0
+
+    for user in users:
+        user["latest_activity_ts"] = max(
+            int(user.get("last_login_ts") or 0),
+            int(user.get("last_message_ts") or 0),
+        )
+
+
+def _sort_user_docs(
+    users: List[Dict[str, Any]],
+    *,
+    sort_by: str,
+    sort_order: str,
+) -> List[Dict[str, Any]]:
+    if sort_by == "user_id":
+        return sorted(
+            users,
+            key=lambda user: str(user["user_id"]),
+            reverse=sort_order == "desc",
+        )
+
+    value_key = "latest_activity_ts" if sort_by == "latest_activity" else sort_by
+    reverse_primary = sort_order == "desc"
+    return sorted(
+        users,
+        key=lambda user: (
+            -int(user.get(value_key) or 0)
+            if reverse_primary
+            else int(user.get(value_key) or 0),
+            str(user["user_id"]),
+        ),
+    )

--- a/synapse_pangea_chat/user_activity/user_activity.py
+++ b/synapse_pangea_chat/user_activity/user_activity.py
@@ -19,7 +19,13 @@ from synapse_pangea_chat.user_activity.get_course_activities import (
     get_course_activities,
 )
 from synapse_pangea_chat.user_activity.get_user_courses import get_user_courses
-from synapse_pangea_chat.user_activity.get_users import get_users
+from synapse_pangea_chat.user_activity.get_users import (
+    DEFAULT_USER_ACTIVITY_SORT_BY,
+    DEFAULT_USER_ACTIVITY_SORT_ORDER,
+    USER_ACTIVITY_SORT_BY_VALUES,
+    USER_ACTIVITY_SORT_ORDER_VALUES,
+    get_users,
+)
 
 if TYPE_CHECKING:
     from synapse_pangea_chat.config import PangeaChatConfig
@@ -59,6 +65,9 @@ class UserActivity(_AdminResourceBase):
                                   N ms. Requires the
                                   user_activity_notification_bot_user_id module
                                   config field to be set.
+      sort_by               str  user_id|last_login_ts|last_message_ts|
+                                  latest_activity (default user_id)
+      sort_order            str  asc|desc (default asc)
 
     NOTE: notification_cooldown_ms performs O(N candidates) account-data
     lookups server-side. Use user_ids or course_ids to narrow the candidate
@@ -92,6 +101,40 @@ class UserActivity(_AdminResourceBase):
             notification_cooldown_ms = _optional_int_param(
                 request, b"notification_cooldown_ms", minimum=1
             )
+            sort_by = _enum_param(
+                request,
+                b"sort_by",
+                default=DEFAULT_USER_ACTIVITY_SORT_BY,
+                allowed=USER_ACTIVITY_SORT_BY_VALUES,
+            )
+            if sort_by is None:
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": "Invalid sort_by. Expected one of: "
+                        + ", ".join(sorted(USER_ACTIVITY_SORT_BY_VALUES))
+                    },
+                    send_cors=True,
+                )
+                return
+            sort_order = _enum_param(
+                request,
+                b"sort_order",
+                default=DEFAULT_USER_ACTIVITY_SORT_ORDER,
+                allowed=USER_ACTIVITY_SORT_ORDER_VALUES,
+            )
+            if sort_order is None:
+                respond_with_json(
+                    request,
+                    400,
+                    {
+                        "error": "Invalid sort_order. Expected one of: "
+                        + ", ".join(sorted(USER_ACTIVITY_SORT_ORDER_VALUES))
+                    },
+                    send_cors=True,
+                )
+                return
 
             if notification_cooldown_ms is not None and not (
                 self._config.user_activity_notification_bot_user_id
@@ -118,6 +161,8 @@ class UserActivity(_AdminResourceBase):
                 notification_cooldown_ms=notification_cooldown_ms,
                 bot_user_id=self._config.user_activity_notification_bot_user_id,
                 api=self._api,
+                sort_by=sort_by,
+                sort_order=sort_order,
             )
 
             respond_with_json(request, 200, data, send_cors=True)
@@ -330,6 +375,22 @@ def _list_param(request: SynapseRequest, name: bytes) -> list[str] | None:
     if raw is None:
         return None
     return [v.strip() for v in raw.split(",") if v.strip()]
+
+
+def _enum_param(
+    request: SynapseRequest,
+    name: bytes,
+    *,
+    default: str,
+    allowed: set[str],
+) -> str | None:
+    raw = _str_param(request, name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in allowed:
+        return value
+    return None
 
 
 def _optional_int_param(

--- a/tests/test_user_activity_e2e.py
+++ b/tests/test_user_activity_e2e.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 
+import psycopg2
 import requests
+import yaml
 
 from .base_e2e import BaseSynapseE2ETest
 
@@ -15,6 +17,67 @@ logging.basicConfig(
 
 
 class TestUserActivityE2E(BaseSynapseE2ETest):
+    def _db_args_from_config(self, config_path: str) -> dict:
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+        return config["database"]["args"]
+
+    def _replace_last_login_ts(
+        self,
+        config_path: str,
+        user_id: str,
+        timestamp_ms: int | None,
+    ) -> None:
+        db_args = self._db_args_from_config(config_path)
+        with psycopg2.connect(**db_args) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("DELETE FROM user_ips WHERE user_id = %s", (user_id,))
+                if timestamp_ms is not None:
+                    cursor.execute(
+                        """
+                        INSERT INTO user_ips (
+                            user_id, access_token, device_id, ip, user_agent, last_seen
+                        ) VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            user_id,
+                            f"test-access-token:{user_id}",
+                            None,
+                            "127.0.0.1",
+                            "test-user-activity-sort",
+                            timestamp_ms,
+                        ),
+                    )
+
+    def _set_event_origin_server_ts(
+        self,
+        config_path: str,
+        event_id: str,
+        timestamp_ms: int,
+    ) -> None:
+        db_args = self._db_args_from_config(config_path)
+        with psycopg2.connect(**db_args) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE events SET origin_server_ts = %s WHERE event_id = %s",
+                    (timestamp_ms, event_id),
+                )
+                self.assertEqual(cursor.rowcount, 1)
+
+    def _user_activity_docs(
+        self,
+        admin_token: str,
+        params: dict[str, str],
+    ) -> list[dict]:
+        response = requests.get(
+            f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+            params=params,
+            headers={"Authorization": f"Bearer {admin_token}"},
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()["docs"]
+
     async def test_user_activity_requires_admin(self):
         """Non-admin users should get 403 from the user_activity endpoint."""
         postgres = None
@@ -119,6 +182,261 @@ class TestUserActivityE2E(BaseSynapseE2ETest):
             user_ids = [u["user_id"] for u in data["docs"]]
             self.assertIn("@admin:my.domain.name", user_ids)
             self.assertIn("@user1:my.domain.name", user_ids)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_user_activity_sorting_and_latest_activity_pagination(self):
+        """Sort params order users globally before pagination and expose the sort key."""
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse()
+
+            for username, password, admin in [
+                ("admin", "adminpw", True),
+                ("loginonly", "pw1", False),
+                ("messageonly", "pw2", False),
+                ("both", "pw3", False),
+                ("never", "pw4", False),
+                ("tie", "pw5", False),
+            ]:
+                await self.register_user(
+                    config_path=config_path,
+                    dir=synapse_dir,
+                    user=username,
+                    password=password,
+                    admin=admin,
+                )
+
+            admin_id, admin_token = await self.login_user("admin", "adminpw")
+            loginonly_id, _ = await self.login_user("loginonly", "pw1")
+            messageonly_id, messageonly_token = await self.login_user(
+                "messageonly", "pw2"
+            )
+            both_id, both_token = await self.login_user("both", "pw3")
+            never_id = "@never:my.domain.name"
+            tie_id, _ = await self.login_user("tie", "pw5")
+
+            messageonly_room_id = await self.create_private_room(messageonly_token)
+            messageonly_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{messageonly_room_id}"
+                "/send/m.room.message/txn-messageonly-sort",
+                json={"msgtype": "m.text", "body": "message-only activity"},
+                headers={"Authorization": f"Bearer {messageonly_token}"},
+                timeout=30,
+            )
+            self.assertEqual(messageonly_response.status_code, 200)
+            messageonly_event_id = messageonly_response.json()["event_id"]
+
+            both_room_id = await self.create_private_room(both_token)
+            both_response = requests.put(
+                f"{self.server_url}/_matrix/client/v3/rooms/{both_room_id}"
+                "/send/m.room.message/txn-both-sort",
+                json={"msgtype": "m.text", "body": "both login and message"},
+                headers={"Authorization": f"Bearer {both_token}"},
+                timeout=30,
+            )
+            self.assertEqual(both_response.status_code, 200)
+            both_event_id = both_response.json()["event_id"]
+
+            # Seed deterministic activity facts. This avoids relying on Synapse's
+            # periodic user_ips flush timing while still exercising the real HTTP
+            # endpoint and real Postgres-backed queries.
+            self._replace_last_login_ts(config_path, admin_id, 1_000)
+            self._replace_last_login_ts(config_path, loginonly_id, 3_000)
+            self._replace_last_login_ts(config_path, messageonly_id, None)
+            self._set_event_origin_server_ts(config_path, messageonly_event_id, 7_000)
+            self._replace_last_login_ts(config_path, both_id, 9_000)
+            self._set_event_origin_server_ts(config_path, both_event_id, 5_000)
+            self._replace_last_login_ts(config_path, tie_id, 7_000)
+            self._replace_last_login_ts(config_path, never_id, None)
+
+            sorted_user_ids = ",".join(
+                [loginonly_id, messageonly_id, both_id, never_id, tie_id]
+            )
+            expected_latest_activity = {
+                both_id: 9_000,
+                loginonly_id: 3_000,
+                messageonly_id: 7_000,
+                never_id: 0,
+                tie_id: 7_000,
+            }
+
+            default_docs = self._user_activity_docs(
+                admin_token,
+                {"user_ids": sorted_user_ids},
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in default_docs],
+                [both_id, loginonly_id, messageonly_id, never_id, tie_id],
+            )
+            self.assertEqual(
+                {doc["user_id"]: doc["latest_activity_ts"] for doc in default_docs},
+                expected_latest_activity,
+            )
+
+            user_id_desc_docs = self._user_activity_docs(
+                admin_token,
+                {
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "user_id",
+                    "sort_order": "desc",
+                },
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in user_id_desc_docs],
+                [tie_id, never_id, messageonly_id, loginonly_id, both_id],
+            )
+
+            last_login_desc_docs = self._user_activity_docs(
+                admin_token,
+                {
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "last_login_ts",
+                    "sort_order": "desc",
+                },
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in last_login_desc_docs],
+                [both_id, tie_id, loginonly_id, messageonly_id, never_id],
+            )
+
+            last_message_desc_docs = self._user_activity_docs(
+                admin_token,
+                {
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "last_message_ts",
+                    "sort_order": "desc",
+                },
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in last_message_desc_docs],
+                [messageonly_id, both_id, loginonly_id, never_id, tie_id],
+            )
+
+            latest_desc_docs = self._user_activity_docs(
+                admin_token,
+                {
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "latest_activity",
+                    "sort_order": "desc",
+                },
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in latest_desc_docs],
+                [both_id, messageonly_id, tie_id, loginonly_id, never_id],
+            )
+            self.assertEqual(
+                [doc["latest_activity_ts"] for doc in latest_desc_docs],
+                [9_000, 7_000, 7_000, 3_000, 0],
+            )
+
+            latest_asc_docs = self._user_activity_docs(
+                admin_token,
+                {
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "latest_activity",
+                    "sort_order": "asc",
+                },
+            )
+            self.assertEqual(
+                [doc["user_id"] for doc in latest_asc_docs],
+                [never_id, loginonly_id, messageonly_id, tie_id, both_id],
+            )
+
+            page_response = requests.get(
+                f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+                params={
+                    "user_ids": sorted_user_ids,
+                    "sort_by": "latest_activity",
+                    "sort_order": "desc",
+                    "limit": "2",
+                    "page": "2",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(page_response.status_code, 200, page_response.text)
+            page_data = page_response.json()
+            self.assertEqual(page_data["page"], 2)
+            self.assertEqual(page_data["limit"], 2)
+            self.assertEqual(page_data["totalDocs"], 5)
+            self.assertEqual(page_data["maxPage"], 3)
+            self.assertEqual(
+                [doc["user_id"] for doc in page_data["docs"]],
+                [tie_id, loginonly_id],
+            )
+
+            unfiltered_page_1 = requests.get(
+                f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+                params={
+                    "sort_by": "latest_activity",
+                    "sort_order": "desc",
+                    "limit": "3",
+                    "page": "1",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(unfiltered_page_1.status_code, 200, unfiltered_page_1.text)
+            unfiltered_page_1_data = unfiltered_page_1.json()
+            self.assertEqual(unfiltered_page_1_data["totalDocs"], 6)
+            self.assertEqual(
+                [doc["user_id"] for doc in unfiltered_page_1_data["docs"]],
+                [both_id, messageonly_id, tie_id],
+            )
+
+            unfiltered_page_2 = requests.get(
+                f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+                params={
+                    "sort_by": "latest_activity",
+                    "sort_order": "desc",
+                    "limit": "3",
+                    "page": "2",
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(unfiltered_page_2.status_code, 200, unfiltered_page_2.text)
+            self.assertEqual(
+                [doc["user_id"] for doc in unfiltered_page_2.json()["docs"]],
+                [loginonly_id, admin_id, never_id],
+            )
+
+            invalid_sort_response = requests.get(
+                f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+                params={"user_ids": sorted_user_ids, "sort_by": "unknown"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(invalid_sort_response.status_code, 400)
+            self.assertIn("sort_by", invalid_sort_response.json()["error"])
+
+            invalid_order_response = requests.get(
+                f"{self.server_url}/_synapse/client/pangea/v1/user_activity",
+                params={"user_ids": sorted_user_ids, "sort_order": "newest"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+                timeout=30,
+            )
+            self.assertEqual(invalid_order_response.status_code, 400)
+            self.assertIn("sort_order", invalid_order_response.json()["error"])
 
         finally:
             self.stop_synapse(


### PR DESCRIPTION
## Summary
- Add non-breaking user_activity sort_by/sort_order query params with defaults preserving user_id ascending order.
- Add latest_activity_ts to user docs as max(last_login_ts, last_message_ts).
- Sort globally before pagination for last_message_ts/latest_activity ordering.
- Document the new API contract and recommended latest-active caller params.

## Validation
- PYENV_VERSION=system uv run --with black==23.10.0 --with ruff==0.1.1 black --check synapse_pangea_chat tests
- PYENV_VERSION=system uv run --with ruff==0.1.1 ruff check synapse_pangea_chat tests
- PYENV_VERSION=system uv run --extra dev --with 'setuptools<81' python -m unittest -v tests.test_user_activity_e2e

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User activity endpoint now supports sorting by user ID, last login, last message, or latest activity
  * New `latest_activity_ts` field in responses indicates the most recent user activity timestamp

* **Documentation**
  * Updated endpoint documentation to detail new sorting parameters and pagination behavior with `latest_activity_ts` field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->