### PR TITLE
perf(direct-message): fast-path valid DM ensure

### DIFF
--- a/.github/instructions/ensure-direct-message.instructions.md
+++ b/.github/instructions/ensure-direct-message.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "synapse_pangea_chat/direct_message/**,synapse_pangea_chat/__init__.py,tests/test_direct_message_e2e.py"
+applyTo: "synapse_pangea_chat/direct_message/**,synapse_pangea_chat/__init__.py,tests/test_direct_message_e2e.py,tests/test_direct_message_unit.py"
 ---
 
 # Ensure Direct Message — Synapse Module
@@ -19,14 +19,15 @@ Lives in the `direct_message/` sub-package.
 - **Validation**:
   - `user_ids` must be an array of exactly 2 entries.
   - Both entries must be distinct local user IDs.
-- **Response**: Returns the DM room ID plus whether the room was created or reused, and whether `m.direct` was updated for each participant.
+- **Response**: Returns the DM room ID plus whether the room was created or reused, whether `m.direct` was updated for each participant, whether power levels were updated, and an `action` classifier for metrics/logging: `valid_existing_noop`, `repaired_account_data`, `repaired_membership_or_power`, or `created_room`.
 
 ## Behavior
 
 The endpoint guarantees a client-usable DM for the exact two local users in `user_ids`.
 
-- If an existing 1:1 DM already exists for that pair, reuse it.
-- If a reusable room exists but is missing `m.direct` for one or both users, repair `m.direct` for both users.
+- If an existing 1:1 DM already exists for that pair and already has correct `m.direct` entries and admin power levels, return it as `valid_existing_noop` without write-side calls.
+- If a reusable room exists but is missing `m.direct` for one or both users, repair only the missing `m.direct` entries.
+- If a reusable room exists but one participant lacks required power, send only the required power-level repair event.
 - If no reusable room exists, create a private direct room for the pair and then write `m.direct` for both users.
 - The result must behave as a DM in clients from both participants' perspectives, not just the caller's.
 
@@ -41,6 +42,7 @@ The endpoint guarantees a client-usable DM for the exact two local users in `use
 - `m.direct` is part of the contract, not a best-effort side effect.
 - The endpoint must ensure the room appears in both users' `m.direct` account data under the other participant's user ID.
 - Repair is additive: preserve unrelated `m.direct` entries.
+- Do not rewrite unchanged `m.direct`; no-op ensures should avoid account-data writes.
 
 ## Intended Use
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Create or repair a 1:1 DM between two local users without needing either user's 
 
 **Body:** `{ "user_ids": ["@alice:example.com", "@bob:example.com"] }`
 
-Requester must be a Synapse server admin. The endpoint accepts exactly two distinct local user IDs, reuses an existing qualifying DM when possible, and repairs `m.direct` for both users so clients treat the room as a DM.
+Requester must be a Synapse server admin. The endpoint accepts exactly two distinct local user IDs, reuses an existing qualifying DM when possible, and repairs `m.direct`/power levels only when needed so clients treat the room as a DM. A valid existing DM returns as `valid_existing_noop` without write-side calls.
 
 **Response (200):**
 
@@ -266,7 +266,9 @@ Requester must be a Synapse server admin. The endpoint accepts exactly two disti
   "m_direct_updated_for": [
     "@alice:example.com",
     "@bob:example.com"
-  ]
+  ],
+  "power_levels_updated": false,
+  "action": "created_room"
 }
 ```
 

--- a/synapse_pangea_chat/direct_message/ensure_direct_message.py
+++ b/synapse_pangea_chat/direct_message/ensure_direct_message.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from synapse.api.constants import (
@@ -34,6 +35,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(
     "synapse.module.synapse_pangea_chat.direct_message.ensure_direct_message"
 )
+
+ACTION_VALID_EXISTING_NOOP = "valid_existing_noop"
+ACTION_REPAIRED_ACCOUNT_DATA = "repaired_account_data"
+ACTION_REPAIRED_MEMBERSHIP_OR_POWER = "repaired_membership_or_power"
+ACTION_CREATED_ROOM = "created_room"
+
+
+@dataclass(frozen=True)
+class ExistingDirectRoom:
+    room_id: str
+    first_user_direct: dict[str, Sequence[str]]
+    second_user_direct: dict[str, Sequence[str]]
 
 
 class EnsureDirectMessage(Resource):
@@ -92,39 +105,24 @@ class EnsureDirectMessage(Resource):
                 )
                 return
 
-            room_id = await self._find_existing_direct_room(canonical_user_ids)
-            created = room_id is None
-            if room_id is None:
-                room_id = await self._create_direct_room(
-                    requester=requester,
-                    user_ids=canonical_user_ids,
-                )
-
-            power_levels_updated = await self._ensure_admin_power_levels(
+            result = await self._ensure_direct_message_room(
+                requester=requester,
                 user_ids=canonical_user_ids,
-                room_id=room_id,
             )
-
-            m_direct_updated_for: list[str] = []
-            if await self._ensure_direct_entry(
-                canonical_user_ids[0], canonical_user_ids[1], room_id
-            ):
-                m_direct_updated_for.append(canonical_user_ids[0])
-            if await self._ensure_direct_entry(
-                canonical_user_ids[1], canonical_user_ids[0], room_id
-            ):
-                m_direct_updated_for.append(canonical_user_ids[1])
+            logger.info(
+                "ensure_direct_message action=%s created=%s reused=%s "
+                "m_direct_updated_count=%d power_levels_updated=%s",
+                result["action"],
+                result["created"],
+                result["reused"],
+                len(result["m_direct_updated_for"]),
+                result["power_levels_updated"],
+            )
 
             respond_with_json(
                 request,
                 200,
-                {
-                    "room_id": room_id,
-                    "created": created,
-                    "reused": not created,
-                    "m_direct_updated_for": m_direct_updated_for,
-                    "power_levels_updated": power_levels_updated,
-                },
+                result,
                 send_cors=True,
             )
         except (
@@ -145,6 +143,126 @@ class EnsureDirectMessage(Resource):
             respond_with_json(
                 request, 500, {"error": "Internal server error"}, send_cors=True
             )
+
+    async def _ensure_direct_message_room(
+        self,
+        requester: Requester,
+        user_ids: Sequence[str],
+    ) -> dict[str, Any]:
+        existing_room = await self._find_existing_direct_room(user_ids)
+        created = existing_room is None
+        existing_power_content: dict[str, Any] | None = None
+        current_power_users: dict[str, Any] | None = None
+
+        if existing_room is None:
+            room_id = await self._create_direct_room(
+                requester=requester,
+                user_ids=user_ids,
+            )
+        else:
+            room_id = existing_room.room_id
+            existing_power_content, current_power_users = await self._get_power_levels(
+                room_id
+            )
+            if self._existing_room_is_valid_noop(
+                user_ids=user_ids,
+                room_id=room_id,
+                existing_room=existing_room,
+                current_power_users=current_power_users,
+            ):
+                return self._success_payload(
+                    room_id=room_id,
+                    created=False,
+                    m_direct_updated_for=[],
+                    power_levels_updated=False,
+                    action=ACTION_VALID_EXISTING_NOOP,
+                )
+
+        power_levels_updated = await self._ensure_admin_power_levels(
+            user_ids=user_ids,
+            room_id=room_id,
+            existing_content=existing_power_content,
+            current_users=current_power_users,
+        )
+
+        first_direct_map = existing_room.first_user_direct if existing_room else None
+        second_direct_map = existing_room.second_user_direct if existing_room else None
+        m_direct_updated_for: list[str] = []
+        if await self._ensure_direct_entry(
+            user_ids[0], user_ids[1], room_id, direct_map=first_direct_map
+        ):
+            m_direct_updated_for.append(user_ids[0])
+        if await self._ensure_direct_entry(
+            user_ids[1], user_ids[0], room_id, direct_map=second_direct_map
+        ):
+            m_direct_updated_for.append(user_ids[1])
+
+        return self._success_payload(
+            room_id=room_id,
+            created=created,
+            m_direct_updated_for=m_direct_updated_for,
+            power_levels_updated=power_levels_updated,
+            action=self._classify_action(
+                created=created,
+                m_direct_updated_for=m_direct_updated_for,
+                power_levels_updated=power_levels_updated,
+            ),
+        )
+
+    def _success_payload(
+        self,
+        *,
+        room_id: str,
+        created: bool,
+        m_direct_updated_for: Sequence[str],
+        power_levels_updated: bool,
+        action: str,
+    ) -> dict[str, Any]:
+        return {
+            "room_id": room_id,
+            "created": created,
+            "reused": not created,
+            "m_direct_updated_for": list(m_direct_updated_for),
+            "power_levels_updated": power_levels_updated,
+            "action": action,
+        }
+
+    def _classify_action(
+        self,
+        *,
+        created: bool,
+        m_direct_updated_for: Sequence[str],
+        power_levels_updated: bool,
+    ) -> str:
+        if created:
+            return ACTION_CREATED_ROOM
+        if power_levels_updated:
+            return ACTION_REPAIRED_MEMBERSHIP_OR_POWER
+        if m_direct_updated_for:
+            return ACTION_REPAIRED_ACCOUNT_DATA
+        return ACTION_VALID_EXISTING_NOOP
+
+    def _existing_room_is_valid_noop(
+        self,
+        *,
+        user_ids: Sequence[str],
+        room_id: str,
+        existing_room: ExistingDirectRoom,
+        current_power_users: dict[str, Any],
+    ) -> bool:
+        return (
+            self._room_in_direct_map(
+                existing_room.first_user_direct,
+                user_ids[1],
+                room_id,
+            )
+            and self._room_in_direct_map(
+                existing_room.second_user_direct,
+                user_ids[0],
+                room_id,
+            )
+            and self._users_have_admin_power(current_power_users, user_ids)
+        )
 
     def _extract_user_ids(self, body: Any) -> list[str] | None:
         if not isinstance(body, dict):
@@ -175,7 +293,9 @@ class EnsureDirectMessage(Resource):
 
         return canonical_user_ids
 
-    async def _find_existing_direct_room(self, user_ids: Sequence[str]) -> str | None:
+    async def _find_existing_direct_room(
+        self, user_ids: Sequence[str]
+    ) -> ExistingDirectRoom | None:
         store = cast(Any, self._datastores.main)
         first_user_rooms = await store.get_rooms_for_user(user_ids[0])
         second_user_rooms = await store.get_rooms_for_user(user_ids[1])
@@ -193,14 +313,28 @@ class EnsureDirectMessage(Resource):
                 continue
 
             if self._room_in_direct_map(first_user_direct, user_ids[1], room_id):
-                return room_id
+                return ExistingDirectRoom(
+                    room_id=room_id,
+                    first_user_direct=first_user_direct,
+                    second_user_direct=second_user_direct,
+                )
             if self._room_in_direct_map(second_user_direct, user_ids[0], room_id):
-                return room_id
+                return ExistingDirectRoom(
+                    room_id=room_id,
+                    first_user_direct=first_user_direct,
+                    second_user_direct=second_user_direct,
+                )
 
             if await self._looks_like_direct_room(room_id):
                 fallback_room_id = room_id
 
-        return fallback_room_id
+        if fallback_room_id is None:
+            return None
+        return ExistingDirectRoom(
+            room_id=fallback_room_id,
+            first_user_direct=first_user_direct,
+            second_user_direct=second_user_direct,
+        )
 
     async def _get_direct_map(self, user_id: str) -> dict[str, Sequence[str]]:
         direct_map = await self._api.account_data_manager.get_global(
@@ -327,24 +461,51 @@ class EnsureDirectMessage(Resource):
             ratelimit=False,
         )
 
+    async def _get_power_levels(
+        self, room_id: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        state = await self._api.get_room_state(
+            room_id, event_filter=[(EventTypes.PowerLevels, "")]
+        )
+        pl_event = state.get((EventTypes.PowerLevels, ""))
+        existing_content: dict[str, Any] = {}
+        current_users: dict[str, Any] = {}
+        if pl_event is not None:
+            existing_content = dict(pl_event.content)
+            raw_users = existing_content.get("users", {})
+            if isinstance(raw_users, dict):
+                current_users = dict(raw_users)
+        return existing_content, current_users
+
+    def _users_have_admin_power(
+        self, current_users: dict[str, Any], user_ids: Sequence[str]
+    ) -> bool:
+        return all(
+            self._coerce_power(current_users.get(uid, 0)) >= 100 for uid in user_ids
+        )
+
+    def _coerce_power(self, value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
     async def _ensure_admin_power_levels(
-        self, user_ids: Sequence[str], room_id: str
+        self,
+        user_ids: Sequence[str],
+        room_id: str,
+        *,
+        existing_content: dict[str, Any] | None = None,
+        current_users: dict[str, Any] | None = None,
     ) -> bool:
         """Ensure both users have power level 100 in the room.
 
         Returns True if a power levels event was sent, False if no change was needed.
         """
-        state = await self._api.get_room_state(
-            room_id, event_filter=[(EventTypes.PowerLevels, "")]
-        )
-        pl_event = state.get((EventTypes.PowerLevels, ""))
-        current_users: dict = {}
-        existing_content: dict = {}
-        if pl_event is not None:
-            existing_content = dict(pl_event.content)
-            current_users = dict(existing_content.get("users", {}))
+        if existing_content is None or current_users is None:
+            existing_content, current_users = await self._get_power_levels(room_id)
 
-        if all(current_users.get(uid, 0) >= 100 for uid in user_ids):
+        if self._users_have_admin_power(current_users, user_ids):
             return False
 
         new_users = dict(current_users)
@@ -380,9 +541,17 @@ class EnsureDirectMessage(Resource):
         return False
 
     async def _ensure_direct_entry(
-        self, user_id: str, counterpart_user_id: str, room_id: str
+        self,
+        user_id: str,
+        counterpart_user_id: str,
+        room_id: str,
+        *,
+        direct_map: dict[str, Sequence[str]] | None = None,
     ) -> bool:
-        direct_map = await self._get_direct_map(user_id)
+        if direct_map is None:
+            direct_map = await self._get_direct_map(user_id)
+        else:
+            direct_map = dict(direct_map)
         existing_room_ids = direct_map.get(counterpart_user_id, ())
         if not isinstance(existing_room_ids, (list, tuple)):
             existing_room_ids = ()

--- a/tests/test_direct_message_e2e.py
+++ b/tests/test_direct_message_e2e.py
@@ -74,6 +74,7 @@ class TestEnsureDirectMessageE2E(BaseSynapseE2ETest):
             data = response.json()
             self.assertTrue(data["created"])
             self.assertFalse(data["reused"])
+            self.assertEqual(data["action"], "created_room")
             room_id = data["room_id"]
 
             alice_joined = requests.get(
@@ -101,6 +102,7 @@ class TestEnsureDirectMessageE2E(BaseSynapseE2ETest):
             )
             self.assertEqual(bob_m_direct.status_code, 200)
             self.assertIn(room_id, bob_m_direct.json()[alice_user_id])
+
         finally:
             self.stop_synapse(
                 server_process=server_process,
@@ -333,6 +335,7 @@ class TestEnsureDirectMessageE2E(BaseSynapseE2ETest):
             self.assertFalse(data["created"])
             self.assertTrue(data["reused"])
             self.assertTrue(data["power_levels_updated"])
+            self.assertEqual(data["action"], "repaired_membership_or_power")
 
             pl_after = requests.get(
                 f"{self.server_url}/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels",

--- a/tests/test_direct_message_unit.py
+++ b/tests/test_direct_message_unit.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from synapse_pangea_chat.direct_message.ensure_direct_message import (
+    ACTION_CREATED_ROOM,
+    ACTION_REPAIRED_ACCOUNT_DATA,
+    ACTION_REPAIRED_MEMBERSHIP_OR_POWER,
+    ACTION_VALID_EXISTING_NOOP,
+    EnsureDirectMessage,
+    ExistingDirectRoom,
+)
+
+ALICE = "@alice:my.domain.name"
+BOB = "@bob:my.domain.name"
+ROOM_ID = "!dm:my.domain.name"
+
+
+def _handler() -> Any:
+    handler = object.__new__(EnsureDirectMessage)
+    handler._api = MagicMock()
+    handler._api.account_data_manager = MagicMock()
+    handler._api.account_data_manager.put_global = AsyncMock()
+    return handler
+
+
+def _existing_room(
+    *,
+    alice_direct: dict[str, Any] | None = None,
+    bob_direct: dict[str, Any] | None = None,
+) -> ExistingDirectRoom:
+    return ExistingDirectRoom(
+        room_id=ROOM_ID,
+        first_user_direct=alice_direct
+        if alice_direct is not None
+        else {BOB: [ROOM_ID]},
+        second_user_direct=bob_direct if bob_direct is not None else {ALICE: [ROOM_ID]},
+    )
+
+
+class TestEnsureDirectMessageFastPath(unittest.IsolatedAsyncioTestCase):
+    async def test_valid_existing_dm_returns_noop_without_repair_calls(self) -> None:
+        handler = _handler()
+        handler._find_existing_direct_room = AsyncMock(return_value=_existing_room())
+        handler._get_power_levels = AsyncMock(
+            return_value=({"users": {ALICE: 100, BOB: 100}}, {ALICE: 100, BOB: 100})
+        )
+        handler._create_direct_room = AsyncMock()
+        handler._ensure_admin_power_levels = AsyncMock()
+        handler._ensure_direct_entry = AsyncMock()
+
+        result = await handler._ensure_direct_message_room(
+            requester=MagicMock(), user_ids=[ALICE, BOB]
+        )
+
+        self.assertEqual(result["action"], ACTION_VALID_EXISTING_NOOP)
+        self.assertFalse(result["created"])
+        self.assertTrue(result["reused"])
+        self.assertEqual(result["room_id"], ROOM_ID)
+        self.assertEqual(result["m_direct_updated_for"], [])
+        self.assertFalse(result["power_levels_updated"])
+        handler._create_direct_room.assert_not_awaited()
+        handler._ensure_admin_power_levels.assert_not_awaited()
+        handler._ensure_direct_entry.assert_not_awaited()
+        handler._api.account_data_manager.put_global.assert_not_awaited()
+
+    async def test_existing_dm_repairs_only_missing_m_direct(self) -> None:
+        handler = _handler()
+        handler._find_existing_direct_room = AsyncMock(
+            return_value=_existing_room(bob_direct={})
+        )
+        handler._get_power_levels = AsyncMock(
+            return_value=({"users": {ALICE: 100, BOB: 100}}, {ALICE: 100, BOB: 100})
+        )
+        handler._ensure_admin_power_levels = AsyncMock(return_value=False)
+        handler._ensure_direct_entry = AsyncMock(side_effect=[False, True])
+
+        result = await handler._ensure_direct_message_room(
+            requester=MagicMock(), user_ids=[ALICE, BOB]
+        )
+
+        self.assertEqual(result["action"], ACTION_REPAIRED_ACCOUNT_DATA)
+        self.assertEqual(result["m_direct_updated_for"], [BOB])
+        self.assertFalse(result["power_levels_updated"])
+        handler._ensure_admin_power_levels.assert_awaited_once()
+        self.assertEqual(handler._ensure_direct_entry.await_count, 2)
+
+    async def test_existing_dm_repairs_power_without_account_data_writes(self) -> None:
+        handler = _handler()
+        handler._find_existing_direct_room = AsyncMock(return_value=_existing_room())
+        handler._get_power_levels = AsyncMock(
+            return_value=({"users": {ALICE: 100}}, {ALICE: 100})
+        )
+        handler._ensure_admin_power_levels = AsyncMock(return_value=True)
+        handler._ensure_direct_entry = AsyncMock(side_effect=[False, False])
+
+        result = await handler._ensure_direct_message_room(
+            requester=MagicMock(), user_ids=[ALICE, BOB]
+        )
+
+        self.assertEqual(result["action"], ACTION_REPAIRED_MEMBERSHIP_OR_POWER)
+        self.assertEqual(result["m_direct_updated_for"], [])
+        self.assertTrue(result["power_levels_updated"])
+        self.assertEqual(handler._ensure_direct_entry.await_count, 2)
+        handler._api.account_data_manager.put_global.assert_not_awaited()
+
+    async def test_missing_dm_reports_created_room(self) -> None:
+        handler = _handler()
+        handler._find_existing_direct_room = AsyncMock(return_value=None)
+        handler._create_direct_room = AsyncMock(return_value=ROOM_ID)
+        handler._ensure_admin_power_levels = AsyncMock(return_value=False)
+        handler._ensure_direct_entry = AsyncMock(side_effect=[True, True])
+
+        result = await handler._ensure_direct_message_room(
+            requester=MagicMock(), user_ids=[ALICE, BOB]
+        )
+
+        self.assertEqual(result["action"], ACTION_CREATED_ROOM)
+        self.assertTrue(result["created"])
+        self.assertFalse(result["reused"])
+        self.assertEqual(result["m_direct_updated_for"], [ALICE, BOB])
+
+    async def test_preloaded_m_direct_entry_does_not_reread_or_rewrite(self) -> None:
+        handler = _handler()
+        handler._get_direct_map = AsyncMock()
+
+        updated = await handler._ensure_direct_entry(
+            ALICE,
+            BOB,
+            ROOM_ID,
+            direct_map={BOB: [ROOM_ID]},
+        )
+
+        self.assertFalse(updated)
+        handler._get_direct_map.assert_not_awaited()
+        handler._api.account_data_manager.put_global.assert_not_awaited()


### PR DESCRIPTION
## What
- Refactor `ensure_direct_message` into a testable core helper that classifies the operation outcome.
- Add a valid-existing-DM fast path that returns `valid_existing_noop` without invoking repair/create helpers when the existing room already has both `m.direct` entries and admin power levels.
- Reuse preloaded `m.direct` maps during repair so unchanged account-data entries are not re-read or rewritten.
- Add response/logging `action` values for `valid_existing_noop`, `repaired_account_data`, `repaired_membership_or_power`, and `created_room`.
- Document the new response field and no-op behavior.

## Why
This is the Synapse-side companion to the re-engagement load-control work. Repeated `ensure_direct_message` calls for already-valid bot/user DMs should be a cheap read/no-op path, while stale rooms still repair only the missing account-data or power-level state.

Closes #131.

Related bot work: pangeachat/pangea-bot#1370 / pangeachat/pangea-bot#1371.

## Testing
- `uv run --extra dev --with 'setuptools<81' python -m py_compile synapse_pangea_chat/direct_message/ensure_direct_message.py tests/test_direct_message_unit.py`
- `uv run --extra dev --with 'setuptools<81' python -m unittest -v tests.test_direct_message_unit`
- `uv run --extra dev --with 'setuptools<81' python -m twisted.trial tests.test_direct_message_unit`
- `uv run --extra dev --with 'setuptools<81' python -m twisted.trial tests.test_direct_message_e2e`
- `uv run --extra dev --with 'setuptools<81' black --check --diff synapse_pangea_chat/direct_message/ensure_direct_message.py tests/test_direct_message_unit.py tests/test_direct_message_e2e.py`
- `uv run --extra dev --with 'setuptools<81' ruff --diff synapse_pangea_chat/direct_message/ensure_direct_message.py tests/test_direct_message_unit.py tests/test_direct_message_e2e.py`
- `uv run --extra dev --with 'setuptools<81' mypy synapse_pangea_chat/direct_message/ensure_direct_message.py tests/test_direct_message_unit.py tests/test_direct_message_e2e.py`
- `git diff --check`

Note: local validation pins `setuptools<81` because Synapse 1.124 imports `pkg_resources`; otherwise the local uv Python 3.14 env lacks that module.

## Deploy notes
No deploy note required. This keeps the same endpoint and request shape, adds a backward-compatible response `action` field, and reduces writes on already-valid rooms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct message endpoint now returns an `action` field describing what operation was performed (room created, repaired, or reused).

* **Documentation**
  * Updated endpoint documentation to clarify direct message behavior, including no-op handling for existing rooms and repair scenarios for account data and power levels.

* **Tests**
  * Added comprehensive unit tests for direct message room handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->