### PR TITLE
fix(room-preview): whitelist pangea.activity_plan content to reference keys

### DIFF
--- a/synapse_pangea_chat/room_preview/get_room_preview.py
+++ b/synapse_pangea_chat/room_preview/get_room_preview.py
@@ -11,9 +11,16 @@ from synapse_pangea_chat.room_preview.constants import (
     EVENT_TYPE_M_ROOM_MEMBER,
     JOIN_RULE_CONTENT_KEY,
     MEMBERSHIP_CONTENT_KEY,
+    PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE,
     PANGEA_ACTIVITY_ROLE_STATE_EVENT_TYPE,
     PANGEA_COURSE_PLAN_STATE_EVENT_TYPE,
 )
+
+# Reference keys safe to expose for pangea.activity_plan in the unauthenticated
+# room preview. Under activities-v2 the event carries only a reference, but
+# legacy rooms still embed the full plan body (title, description, goals, vocab,
+# media) in this state event; only the reference is exposed publicly.
+ACTIVITY_PLAN_PREVIEW_KEYS = ("activity_id", "version_id", "source_course_id")
 
 if TYPE_CHECKING:
     from synapse_pangea_chat.config import PangeaChatConfig
@@ -96,6 +103,30 @@ def _filter_join_rules_content(event_data: Dict[str, Any]) -> Dict[str, Any]:
         filtered_content[JOIN_RULE_CONTENT_KEY] = content[JOIN_RULE_CONTENT_KEY]
 
     # Create a copy of the event data with filtered content
+    filtered_event = event_data.copy()
+    filtered_event["content"] = filtered_content
+
+    return filtered_event
+
+
+def _filter_activity_plan_content(event_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Project pangea.activity_plan content to the safe reference keys for the
+    unauthenticated preview (mirrors _filter_join_rules_content).
+
+    Legacy activity rooms embed the full plan body in this state event; only the
+    reference (activity_id, version_id, source_course_id) is ever exposed in the
+    public preview, never the activity body, goals, or media.
+    """
+    if not isinstance(event_data, dict):
+        return event_data
+
+    content = event_data.get("content", {})
+    if not isinstance(content, dict):
+        return event_data
+
+    filtered_content = {
+        key: content[key] for key in ACTIVITY_PLAN_PREVIEW_KEYS if key in content
+    }
     filtered_event = event_data.copy()
     filtered_event["content"] = filtered_content
 
@@ -330,6 +361,10 @@ async def get_room_preview(
         # Filter m.room.join_rules content to only include join_rule key
         if event_type == EVENT_TYPE_M_ROOM_JOIN_RULES:
             event_data = _filter_join_rules_content(event_data)
+        # Project pangea.activity_plan to its safe reference keys so a legacy
+        # room's embedded plan body never reaches the unauthenticated preview.
+        elif event_type == PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE:
+            event_data = _filter_activity_plan_content(event_data)
 
         fetched_room_data[room_id][event_type][key] = event_data
 

--- a/tests/test_room_preview_e2e.py
+++ b/tests/test_room_preview_e2e.py
@@ -350,26 +350,20 @@ class TestE2E(BaseSynapseE2ETest):
         # Add additional state events
         state_url = f"http://localhost:8008/_matrix/client/v3/rooms/{room_id}/state"
 
-        # Add pangea.activity_plan state event
+        # Add pangea.activity_plan state event. This simulates a legacy room
+        # that embeds the full plan body alongside the reference keys; the
+        # preview must project it to only the reference (activity_id,
+        # version_id, source_course_id) and strip the embedded body.
         activity_plan_data = {
-            "plan_id": "plan123",
+            "activity_id": "act-123",
+            "version_id": "0123456789abcdef0123456789abcdef",
+            "source_course_id": "!course:my.domain.name",
+            # Embedded body (legacy) — must NOT appear in the public preview.
             "title": "Weekly Team Standup",
             "description": "Regular team sync meeting to discuss progress and blockers",
             "activities": [
-                {
-                    "id": "activity1",
-                    "name": "Progress Updates",
-                    "duration": 15,
-                    "type": "discussion",
-                },
-                {
-                    "id": "activity2",
-                    "name": "Blockers Review",
-                    "duration": 10,
-                    "type": "problem_solving",
-                },
+                {"id": "activity1", "name": "Progress Updates"},
             ],
-            "total_duration": 25,
             "created_by": "@admin_user:my.domain.name",
         }
 
@@ -487,23 +481,26 @@ class TestE2E(BaseSynapseE2ETest):
                         f"Event type {event_type} should contain 'content' field in full Matrix event",
                     )
 
-                    # For pangea.activity_plan, verify it has the expected content fields
+                    # For pangea.activity_plan, the preview must expose ONLY the
+                    # reference keys and strip the embedded plan body.
                     if event_type == "pangea.activity_plan":
-                        # Access the content field within the full Matrix event
                         content = full_event.get("content", {})
-                        expected_fields = [
-                            "plan_id",
-                            "title",
-                            "description",
-                            "activities",
-                            "total_duration",
-                            "created_by",
-                        ]
-                        for field in expected_fields:
+                        for field in ("activity_id", "version_id", "source_course_id"):
                             self.assertIn(
                                 field,
                                 content,
-                                f"Activity plan content should contain field '{field}'",
+                                f"Activity plan preview should keep reference field '{field}'",
+                            )
+                        for leaked in (
+                            "title",
+                            "description",
+                            "activities",
+                            "created_by",
+                        ):
+                            self.assertNotIn(
+                                leaked,
+                                content,
+                                f"Activity plan preview must NOT leak body field '{leaked}'",
                             )
 
                     # Verify there are no empty string state keys when using "default"


### PR DESCRIPTION
## What
Project `pangea.activity_plan` to its reference keys in the unauthenticated room preview, stripping any embedded plan body.

## Why
Closes #134. Part of pangeachat/.github#199. The activities-v2 `pangea.activity_plan` event is surfaced verbatim in the public preview; legacy rooms embed the full plan body there, so the preview could leak activity content. New `_filter_activity_plan_content` keeps only `activity_id` / `version_id` / `source_course_id`, mirroring `_filter_join_rules_content`.

## Testing
- Verified the filter logic + clean module import against the worktree code via the repo venv (keeps the three reference keys, strips body fields, passes non-dict content through). `mypy` and `black` clean on the changed files.
- Updated the room-preview integration test fixture/assertions: the activity_plan event now carries both reference keys and an embedded body, and the test asserts only the reference survives (body fields stripped). The integration suite (local Synapse + Postgres via `testing.postgresql`) runs in CI; I did not stand that harness up in the worktree.

## Deploy Notes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
