### PR TITLE
docs: fix stale repo name in workspace plan

### DIFF
--- a/.workspace/2026-03-31/direct-push-endpoint-plan.md
+++ b/.workspace/2026-03-31/direct-push-endpoint-plan.md
@@ -1,7 +1,7 @@
 # Plan: Direct Push Endpoint on Synapse Module
 
 - Date: 2026-03-31
-- Repo: `synapse-pangea-chat-modules`
+- Repo: `synapse-pangea-chat`
 - Scope decided here:
   - Add an admin-only HTTP endpoint in the Synapse module for immediate push delivery without creating any Matrix event.
   - Treat this as a Synapse-module and Sygnal delivery design, with only a short client-implications section.


### PR DESCRIPTION
Corrects a stale repo reference in the direct-push endpoint planning doc under `.workspace/2026-03-31/`. Line 4 named the repo `synapse-pangea-chat-modules`; the repo is now `synapse-pangea-chat`. One-line name fix, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)