### PR TITLE
fix(public-courses): match language filters by base language, not CMS exact equality

### DIFF
--- a/.github/instructions/public-courses.instructions.md
+++ b/.github/instructions/public-courses.instructions.md
@@ -19,6 +19,7 @@ Public course discovery endpoint for course catalog surfaces in clients and oper
 - Rate limiting behavior is shared across both routes.
 - Query params and response schema must stay identical across aliases.
 - Filtering behavior is defined by the shared `PublicCourses` resource and must not diverge by path.
+- Language filters (`target_language`, `language_of_instructions`) match by BASE language: `es` matches courses whose CMS `l2`/`originalL1` is `es`, `es-ES`, or `es-MX`, and vice versa — the same exact-or-base rule as the bot's supported-L2 checks. Exact CMS equality drops regionally-tagged courses and empties the list (issue #53). CEFR filtering stays exact.
 
 ## Compatibility
 

--- a/synapse_pangea_chat/public_courses/course_metadata_cache.py
+++ b/synapse_pangea_chat/public_courses/course_metadata_cache.py
@@ -97,23 +97,35 @@ async def _cms_get(
 
 def _build_where_params(
     course_uuids: List[str],
-    target_language: Optional[str] = None,
-    language_of_instructions: Optional[str] = None,
     cefr_level: Optional[str] = None,
 ) -> Dict[str, str]:
-    """Build Payload CMS ``where`` query parameters."""
+    """Build Payload CMS ``where`` query parameters.
+
+    Language filters are deliberately NOT pushed to CMS: course ``l2`` /
+    ``originalL1`` values may carry regional tags (``es-ES``) while
+    clients filter by base code (``es``), and CMS ``equals`` would drop
+    those courses — on staging this made the filtered course list come
+    back empty (issue #53). Language matching happens module-side via
+    ``_language_matches``; only exact-valued filters (CEFR) stay in the
+    CMS query.
+    """
     params: Dict[str, str] = {
         "where[id][in]": ",".join(course_uuids),
         "limit": str(len(course_uuids)),
         "depth": "0",
     }
-    if target_language:
-        params["where[l2][equals]"] = target_language
-    if language_of_instructions:
-        params["where[originalL1][equals]"] = language_of_instructions
     if cefr_level:
         params["where[cefrLevel][equals]"] = cefr_level
     return params
+
+
+def _language_matches(candidate: str, filter_value: str) -> bool:
+    """Base-language match: ``es`` matches ``es``, ``es-ES``, ``es-MX``
+    (and vice versa). Same rule as the bot's supported-L2 checks —
+    exact matches and base-language matches both count."""
+    if not candidate or not filter_value:
+        return False
+    return candidate.split("-")[0].lower() == filter_value.split("-")[0].lower()
 
 
 async def get_course_metadata(
@@ -172,22 +184,31 @@ async def get_filtered_course_ids(
 ) -> Dict[str, CourseMeta]:
     """Return metadata only for courses matching the given filters.
 
-    Delegates filtering to CMS via ``where`` clauses so only matching
-    documents are returned.  Results are cached per-UUID for later
-    unfiltered lookups.
+    Exact-valued filters (CEFR) are delegated to CMS ``where`` clauses;
+    language filters are applied module-side with base-language matching
+    (see ``_build_where_params`` / ``_language_matches``, issue #53).
+    Results are cached per-UUID for later unfiltered lookups.
     """
     if not course_uuids:
         return {}
 
     try:
-        params = _build_where_params(
-            course_uuids,
-            target_language=target_language,
-            language_of_instructions=language_of_instructions,
-            cefr_level=cefr_level,
-        )
+        params = _build_where_params(course_uuids, cefr_level=cefr_level)
         docs = await _cms_get(cms_base_url, cms_api_key, params)
-        return _parse_docs(docs)
+        parsed = _parse_docs(docs)
+        if target_language:
+            parsed = {
+                uuid: meta
+                for uuid, meta in parsed.items()
+                if _language_matches(meta["l2"], target_language)
+            }
+        if language_of_instructions:
+            parsed = {
+                uuid: meta
+                for uuid, meta in parsed.items()
+                if _language_matches(meta["l1"], language_of_instructions)
+            }
+        return parsed
     except Exception as exc:
         logger.warning(
             "Failed to fetch filtered course metadata from CMS",

--- a/tests/mock_cms_server.py
+++ b/tests/mock_cms_server.py
@@ -42,10 +42,28 @@ class _MockCmsHandler(BaseHTTPRequestHandler):
 
     # --- routing ---
 
+    def _require_any_api_key_auth(self) -> bool:
+        """Accept any `<collection> API-Key <key>` scheme.
+
+        The public_courses module authenticates as `users API-Key ...`
+        while the export flow uses `service-users API-Key ...`; routes
+        used by both only care that an API key is presented.
+        """
+        auth_header = self.headers.get("Authorization", "")
+        if " API-Key " not in auth_header:
+            self._send_json(401, {"error": "Unauthorized"})
+            return False
+        return True
+
     def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/course-plans":
+            if not self._require_any_api_key_auth():
+                return
+            self._handle_get_course_plans(parsed.query)
+            return
         if not self._require_service_user_auth():
             return
-        parsed = urlparse(self.path)
         if parsed.path == "/api/matrix-users":
             self._handle_get_matrix_users(parsed.query)
         else:
@@ -75,6 +93,34 @@ class _MockCmsHandler(BaseHTTPRequestHandler):
 
         state: "_MockCmsState" = self.server._state  # type: ignore[attr-defined]
         docs = state.get_matrix_users(username)
+        self._send_json(200, {"docs": docs})
+
+    def _handle_get_course_plans(self, query_string: str) -> None:
+        """Payload-compatible course-plans query.
+
+        Implements the operators the public_courses module sends:
+        `where[id][in]`, `where[l2][equals]`, `where[originalL1][equals]`,
+        `where[cefrLevel][equals]` — with Payload's exact-equality
+        semantics, so tests exercise the real CMS behavior.
+        """
+        qs = parse_qs(query_string)
+
+        def _single(key: str) -> Optional[str]:
+            return qs.get(key, [None])[0]
+
+        ids_param = _single("where[id][in]")
+        ids = ids_param.split(",") if ids_param else []
+        filters = {
+            "l2": _single("where[l2][equals]"),
+            "originalL1": _single("where[originalL1][equals]"),
+            "cefrLevel": _single("where[cefrLevel][equals]"),
+        }
+
+        state: "_MockCmsState" = self.server._state  # type: ignore[attr-defined]
+        docs = state.get_course_plans(ids)
+        for field, value in filters.items():
+            if value is not None:
+                docs = [d for d in docs if d.get(field) == value]
         self._send_json(200, {"docs": docs})
 
     # --- user-exports handlers ---
@@ -137,6 +183,7 @@ class _MockCmsState:
         self._matrix_users_by_username: Dict[str, Dict[str, Any]] = {}
         self._matrix_users_by_id: Dict[str, Dict[str, Any]] = {}
         self._exports_by_id: Dict[str, Dict[str, Any]] = {}
+        self._course_plans_by_id: Dict[str, Dict[str, Any]] = {}
 
     def seed_matrix_user(self, username: str) -> Dict[str, Any]:
         with self._lock:
@@ -148,6 +195,32 @@ class _MockCmsState:
             self._matrix_users_by_username[username] = doc
             self._matrix_users_by_id[doc["id"]] = doc
             return dict(doc)
+
+    def seed_course_plan(
+        self,
+        l2: str,
+        original_l1: str = "en",
+        cefr_level: str = "A1",
+        title: str = "Test course",
+    ) -> Dict[str, Any]:
+        doc = {
+            "id": str(uuid.uuid4()),
+            "l2": l2,
+            "originalL1": original_l1,
+            "cefrLevel": cefr_level,
+            "title": title,
+        }
+        with self._lock:
+            self._course_plans_by_id[doc["id"]] = doc
+        return dict(doc)
+
+    def get_course_plans(self, ids: List[str]) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [
+                dict(self._course_plans_by_id[i])
+                for i in ids
+                if i in self._course_plans_by_id
+            ]
 
     def get_matrix_users(self, username: Optional[str]) -> List[Dict[str, Any]]:
         with self._lock:
@@ -235,6 +308,17 @@ class MockCmsServer:
 
     def seed_matrix_user(self, username: str) -> Dict[str, Any]:
         return self._state.seed_matrix_user(username)
+
+    def seed_course_plan(
+        self,
+        l2: str,
+        original_l1: str = "en",
+        cefr_level: str = "A1",
+        title: str = "Test course",
+    ) -> Dict[str, Any]:
+        return self._state.seed_course_plan(
+            l2, original_l1=original_l1, cefr_level=cefr_level, title=title
+        )
 
     def get_exports_for_matrix_user_id(
         self, matrix_user_id: str

--- a/tests/test_course_metadata_cache.py
+++ b/tests/test_course_metadata_cache.py
@@ -145,9 +145,16 @@ class TestGetFilteredCourseIds(unittest.IsolatedAsyncioTestCase):
         _meta_cache.clear()
 
     @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
-    async def test_passes_filters_to_cms(self, mock_cms_get: AsyncMock) -> None:
+    async def test_cefr_delegated_languages_filtered_module_side(
+        self, mock_cms_get: AsyncMock
+    ) -> None:
+        # Language filters must NOT reach CMS as `equals` clauses — exact
+        # equality drops regionally-tagged courses (issue #53). Only the
+        # exact-valued CEFR filter is delegated; languages are matched
+        # module-side by base language.
         mock_cms_get.return_value = [
             {"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+            {"id": "uuid-2", "l2": "fr", "originalL1": "en", "cefrLevel": "A1"},
         ]
         result = await get_filtered_course_ids(
             ["uuid-1", "uuid-2"],
@@ -162,8 +169,8 @@ class TestGetFilteredCourseIds(unittest.IsolatedAsyncioTestCase):
 
         call_args = mock_cms_get.call_args
         params = call_args[1].get("query_params") or call_args[0][2]
-        self.assertEqual(params["where[l2][equals]"], "es")
-        self.assertEqual(params["where[originalL1][equals]"], "en")
+        self.assertNotIn("where[l2][equals]", params)
+        self.assertNotIn("where[originalL1][equals]", params)
         self.assertEqual(params["where[cefrLevel][equals]"], "A1")
         self.assertEqual(params["limit"], "2")
         self.assertEqual(params["depth"], "0")
@@ -171,8 +178,37 @@ class TestGetFilteredCourseIds(unittest.IsolatedAsyncioTestCase):
         self.assertIn("uuid-2", params["where[id][in]"])
 
     @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
+    async def test_base_language_matches_regional_l2(
+        self, mock_cms_get: AsyncMock
+    ) -> None:
+        # The issue-#53 repro at unit level: `es` must match `es-ES`, and
+        # a regional filter must match across the base language.
+        mock_cms_get.return_value = [
+            {"id": "uuid-1", "l2": "es-ES", "originalL1": "en", "cefrLevel": "A1"},
+            {"id": "uuid-2", "l2": "es", "originalL1": "en", "cefrLevel": "A1"},
+            {"id": "uuid-3", "l2": "fr", "originalL1": "en", "cefrLevel": "A1"},
+        ]
+        result = await get_filtered_course_ids(
+            ["uuid-1", "uuid-2", "uuid-3"],
+            "https://cms.test",
+            "api-key-123",
+            target_language="es",
+        )
+        self.assertEqual(sorted(result), ["uuid-1", "uuid-2"])
+
+        _meta_cache.clear()
+        result = await get_filtered_course_ids(
+            ["uuid-1", "uuid-2", "uuid-3"],
+            "https://cms.test",
+            "api-key-123",
+            target_language="es-MX",
+        )
+        self.assertEqual(sorted(result), ["uuid-1", "uuid-2"])
+
+    @patch("synapse_pangea_chat.public_courses.course_metadata_cache._cms_get")
     async def test_partial_filters(self, mock_cms_get: AsyncMock) -> None:
         mock_cms_get.return_value = [
+            {"id": "uuid-1", "l2": "es", "originalL1": "en", "cefrLevel": "B1"},
             {"id": "uuid-2", "l2": "fr", "originalL1": "en", "cefrLevel": "B1"},
         ]
         result = await get_filtered_course_ids(
@@ -182,10 +218,11 @@ class TestGetFilteredCourseIds(unittest.IsolatedAsyncioTestCase):
             target_language="fr",
         )
         self.assertEqual(len(result), 1)
+        self.assertIn("uuid-2", result)
 
         call_args = mock_cms_get.call_args
         params = call_args[1].get("query_params") or call_args[0][2]
-        self.assertEqual(params["where[l2][equals]"], "fr")
+        self.assertNotIn("where[l2][equals]", params)
         self.assertNotIn("where[originalL1][equals]", params)
         self.assertNotIn("where[cefrLevel][equals]", params)
 

--- a/tests/test_public_courses_language_filter_e2e.py
+++ b/tests/test_public_courses_language_filter_e2e.py
@@ -1,0 +1,157 @@
+"""E2E test for the public_courses target-language filter (issue #53).
+
+Reproduces the reported failure: courses whose CMS ``l2`` carries a
+regional tag (``es-ES``) are invisible to a base-code filter
+(``target_language=es``) when filtering uses exact CMS equality — the
+course list comes back empty even though matching-language courses
+exist. Language filtering must accept base-language matches (the same
+rule the bot's supported-L2 checks follow).
+
+Runs a real local Synapse + PostgreSQL (BaseSynapseE2ETest) against the
+mock CMS server's Payload-compatible ``/api/course-plans`` route.
+"""
+
+import unittest
+from typing import Any, Dict, List
+
+import requests
+
+from tests.base_e2e import BaseSynapseE2ETest
+from tests.mock_cms_server import MockCmsServer
+
+COURSE_PLAN_EVENT_TYPE = "pangea.course_plan"
+PUBLIC_COURSES_URL = (
+    "http://localhost:8008/_synapse/client/pangea/v1/public_courses"
+)
+
+
+class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
+    async def _create_public_course_room(
+        self, access_token: str, course_uuid: str
+    ) -> str:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        response = requests.post(
+            f"{self.server_url}/_matrix/client/v3/createRoom",
+            json={
+                "visibility": "public",
+                "preset": "public_chat",
+                "initial_state": [
+                    {
+                        "type": COURSE_PLAN_EVENT_TYPE,
+                        "state_key": "",
+                        "content": {"uuid": course_uuid},
+                    }
+                ],
+            },
+            headers=headers,
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["room_id"]
+
+    def _get_courses(
+        self, access_token: str, **params: str
+    ) -> Dict[str, Any]:
+        response = requests.get(
+            PUBLIC_COURSES_URL,
+            params={"limit": "20", **params},
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    async def test_target_language_filter_matches_base_and_regional_l2(
+        self,
+    ) -> None:
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        mock_cms = MockCmsServer()
+
+        try:
+            cms_url = mock_cms.start()
+            base_course = mock_cms.seed_course_plan(l2="es", title="Base Spanish")
+            regional_course = mock_cms.seed_course_plan(
+                l2="es-ES", title="Regional Spanish"
+            )
+            other_course = mock_cms.seed_course_plan(l2="fr", title="French")
+
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "cms_base_url": cms_url,
+                    "cms_service_api_key": "test-cms-api-key",
+                }
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="teacher",
+                password="123123123",
+                admin=True,
+            )
+            _, access_token = await self.login_user(
+                user="teacher", password="123123123"
+            )
+
+            for course in (base_course, regional_course, other_course):
+                await self._create_public_course_room(access_token, course["id"])
+
+            def titles(body: Dict[str, Any]) -> List[str]:
+                return sorted(c.get("name") or "" for c in body["chunk"])
+
+            # Unfiltered: all three rooms are public courses.
+            unfiltered = self._get_courses(access_token)
+            self.assertEqual(unfiltered["filtering_warning"], "")
+            self.assertEqual(len(unfiltered["chunk"]), 3)
+
+            # The issue-#53 repro: a base-code filter must return BOTH the
+            # base-l2 course and the regionally-tagged one. With exact CMS
+            # equality the es-ES course vanishes (and on staging, where
+            # courses carry regional tags, the whole list came back empty).
+            filtered = self._get_courses(access_token, target_language="es")
+            self.assertEqual(filtered["filtering_warning"], "")
+            self.assertEqual(
+                len(filtered["chunk"]),
+                2,
+                f"target_language=es should match l2 es AND es-ES; got "
+                f"{titles(filtered)}",
+            )
+            languages = sorted(
+                c["target_language"] for c in filtered["chunk"]
+            )
+            self.assertEqual(languages, ["es", "es-ES"])
+
+            # Regional filter also matches across the base language.
+            regional = self._get_courses(access_token, target_language="es-ES")
+            self.assertEqual(len(regional["chunk"]), 2)
+
+            # A different language stays excluded.
+            french = self._get_courses(access_token, target_language="fr")
+            self.assertEqual(len(french["chunk"]), 1)
+            self.assertEqual(
+                french["chunk"][0]["target_language"], "fr"
+            )
+        finally:
+            mock_cms.stop()
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #53

## Verification (issue is NOT stale)
New reusable E2E test (`tests/test_public_courses_language_filter_e2e.py`) — real local Synapse + Postgres against a Payload-compatible mock CMS `/api/course-plans` route — reproduced the exact failure before the fix: with courses of `l2 = es` and `l2 = es-ES`, `?target_language=es` returned only 1 of 2 Spanish courses. On staging, where course `l2` values carry regional tags, that's the reported all-empty list (`filtering_warning: ""` matches too — the CMS lookup succeeds, it just exact-matches nothing).

## Root cause
`get_filtered_course_ids` delegated language filters to CMS as `where[l2][equals]` / `where[originalL1][equals]`. The CMS `l2` field validates against the full language list, which includes both base (`es`) and regional (`es-ES`, `es-MX`) codes — exact equality can never bridge them.

## Fix
Language filters now match module-side by **base language** (`es` ↔ `es-ES`/`es-MX`, case-insensitive), the same exact-or-base rule the bot's supported-L2 checks use. The CMS query keeps `where[id][in]` + exact CEFR; still one CMS round-trip. Semantics documented in `public-courses.instructions.md` Behavior.

## Testing
- New E2E test: unfiltered (3 courses), `es` → both Spanish courses, `es-ES` → both, `fr` → French only. Failed pre-fix (`1 != 2`), passes post-fix.
- Mock CMS extended with a course-plans route implementing the Payload operators the module sends (reusable for future public-courses tests).
- Unit tests updated to the new contract + a unit-level regional-match repro.
- Full suite: affected modules all green; one unrelated flake (`test_user_directory_search_e2e.test_self_excluded`) fails under full-suite load but passes standalone twice — untouched by this diff.

Deploys to staging via the Ansible synapse deploy (no prod release implied).

TO TEST
- [ ] Open the course discovery surface and filter courses by target language Spanish — verify Spanish courses appear (including ones whose course language is a regional variant like es-ES)
- [ ] Switch the filter to another language with no courses — verify the list is empty
- [ ] Clear the filter — verify all public courses appear