### PR TITLE
fix(delete_user): bound scheduled delete retries and fail 404s terminally

### DIFF
--- a/.github/instructions/delete-user-export-user-data.instructions.md
+++ b/.github/instructions/delete-user-export-user-data.instructions.md
@@ -36,6 +36,7 @@ Two admin-adjacent Pangea endpoints extend Synapse with controlled account lifec
 - Scheduled work is processed asynchronously on a recurring background loop.
 - The scheduling mechanism must preserve existing behavior across supported Synapse versions, including short test-time intervals.
 - Repeated force runs should be idempotent at the API contract level: callers receive a successful operation rather than a route-level failure when the feature is enabled.
+- Delete retries are bounded, never infinite. Each delete schedule persists an attempt counter; after a small fixed number of failed attempts (5) the schedule is dropped as terminally failed with one final error log naming the user and the terminal reason. Failures that can never succeed on retry (a 404: the user row is already gone) terminate the schedule on the first attempt. A terminally failed schedule holds no state — a fresh `schedule` or `force` request starts over cleanly.
 
 ## Side Effects
 

--- a/synapse_pangea_chat/delete_user/delete_user.py
+++ b/synapse_pangea_chat/delete_user/delete_user.py
@@ -35,6 +35,10 @@ logger = logging.getLogger("synapse.module.synapse_pangea_chat.delete_user")
 SCHEDULE_TABLE = "pangea_delete_user_schedule"
 VALID_ACTIONS = {"schedule", "cancel", "force"}
 
+# A scheduled delete is retried at most this many times before the schedule
+# is dropped as terminally failed.
+MAX_SCHEDULE_ATTEMPTS = 5
+
 
 class _LoopingCallInterval(int):
     def as_secs(self) -> float:
@@ -299,8 +303,17 @@ class DeleteUser(Resource):
                     execute_at_ms BIGINT NOT NULL,
                     requested_at_ms BIGINT NOT NULL,
                     requested_by TEXT NOT NULL,
-                    requested_by_admin BOOLEAN NOT NULL DEFAULT FALSE
+                    requested_by_admin BOOLEAN NOT NULL DEFAULT FALSE,
+                    attempts INTEGER NOT NULL DEFAULT 0
                 )
+                """
+            )
+            # Migrate pre-existing installs that created the table without
+            # the attempts column.
+            txn.execute(
+                f"""
+                ALTER TABLE {SCHEDULE_TABLE}
+                ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0
                 """
             )
             txn.execute(
@@ -322,19 +335,22 @@ class DeleteUser(Resource):
         execute_at_ms: int,
         requested_by: str,
         requested_by_admin: bool,
+        attempts: int = 0,
     ) -> None:
         def _upsert(txn: Any) -> None:
             txn.execute(
                 f"""
                 INSERT INTO {SCHEDULE_TABLE}
-                    (user_id, execute_at_ms, requested_at_ms, requested_by, requested_by_admin)
-                VALUES (%s, %s, %s, %s, %s)
+                    (user_id, execute_at_ms, requested_at_ms, requested_by,
+                     requested_by_admin, attempts)
+                VALUES (%s, %s, %s, %s, %s, %s)
                 ON CONFLICT (user_id)
                 DO UPDATE SET
                     execute_at_ms = EXCLUDED.execute_at_ms,
                     requested_at_ms = EXCLUDED.requested_at_ms,
                     requested_by = EXCLUDED.requested_by,
-                    requested_by_admin = EXCLUDED.requested_by_admin
+                    requested_by_admin = EXCLUDED.requested_by_admin,
+                    attempts = EXCLUDED.attempts
                 """,
                 (
                     user_id,
@@ -342,6 +358,7 @@ class DeleteUser(Resource):
                     self._clock.time_msec(),
                     requested_by,
                     requested_by_admin,
+                    attempts,
                 ),
             )
 
@@ -395,13 +412,19 @@ class DeleteUser(Resource):
                 f"""
                 DELETE FROM {SCHEDULE_TABLE}
                 WHERE execute_at_ms <= %s
-                RETURNING user_id, requested_by_admin
+                RETURNING user_id, requested_by, requested_by_admin, attempts
                 """,
                 (now_ms,),
             )
             rows = txn.fetchall()
             return [
-                {"user_id": row[0], "requested_by_admin": bool(row[1])} for row in rows
+                {
+                    "user_id": row[0],
+                    "requested_by": row[1],
+                    "requested_by_admin": bool(row[2]),
+                    "attempts": int(row[3] or 0),
+                }
+                for row in rows
             ]
 
         return await self._datastores.main.db_pool.runInteraction(
@@ -422,9 +445,30 @@ class DeleteUser(Resource):
                     by_admin=bool(schedule["requested_by_admin"]),
                 )
             except Exception as e:
-                logger.error(
-                    "Failed to process scheduled delete for %s: %s",
+                attempts = int(schedule.get("attempts") or 0) + 1
+                # A 404 means the user row is already gone; retrying can
+                # never succeed, so fail the schedule immediately.
+                permanently_failed = isinstance(e, SynapseError) and e.code == 404
+                if permanently_failed or attempts >= MAX_SCHEDULE_ATTEMPTS:
+                    logger.error(
+                        "Scheduled delete for %s failed terminally after "
+                        "%d attempt(s) (%s), giving up: %s",
+                        user_id,
+                        attempts,
+                        (
+                            "permanent error"
+                            if permanently_failed
+                            else "max attempts reached"
+                        ),
+                        e,
+                    )
+                    continue
+                logger.warning(
+                    "Failed to process scheduled delete for %s "
+                    "(attempt %d of %d), will retry: %s",
                     user_id,
+                    attempts,
+                    MAX_SCHEDULE_ATTEMPTS,
                     e,
                 )
                 retry_at_ms = (
@@ -434,6 +478,7 @@ class DeleteUser(Resource):
                 await self._upsert_schedule(
                     user_id=user_id,
                     execute_at_ms=retry_at_ms,
-                    requested_by=user_id,
+                    requested_by=schedule.get("requested_by") or user_id,
                     requested_by_admin=bool(schedule["requested_by_admin"]),
+                    attempts=attempts,
                 )

--- a/synapse_pangea_chat/room_code/knock_with_code.py
+++ b/synapse_pangea_chat/room_code/knock_with_code.py
@@ -22,15 +22,15 @@ from twisted.internet import defer
 from twisted.web.resource import Resource
 
 from synapse_pangea_chat.room_code.burn_admin_code import burn_admin_code
-from synapse_pangea_chat.room_code.extract_body_json import extract_body_json
-from synapse_pangea_chat.room_code.get_inviter_user import promote_user_to_admin
-from synapse_pangea_chat.room_code.get_rooms_with_access_code import (
-    get_rooms_with_access_code,
-)
 from synapse_pangea_chat.room_code.constants import (
     ERRCODE_BANNED_FROM_ROOM,
     MEMBERSHIP_BAN,
     MEMBERSHIP_JOIN,
+)
+from synapse_pangea_chat.room_code.extract_body_json import extract_body_json
+from synapse_pangea_chat.room_code.get_inviter_user import promote_user_to_admin
+from synapse_pangea_chat.room_code.get_rooms_with_access_code import (
+    get_rooms_with_access_code,
 )
 from synapse_pangea_chat.room_code.invite_user_to_room import invite_user_to_room
 from synapse_pangea_chat.room_code.is_rate_limited import is_rate_limited

--- a/tests/test_delete_user_e2e.py
+++ b/tests/test_delete_user_e2e.py
@@ -87,6 +87,41 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
         finally:
             conn.close()
 
+    def _insert_schedule(
+        self, config_path: str, user_id: str, execute_at_ms: int
+    ) -> None:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                INSERT INTO {self._SCHEDULE_TABLE}
+                    (user_id, execute_at_ms, requested_at_ms, requested_by, requested_by_admin)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (user_id, execute_at_ms, 1, user_id, False),
+            )
+            cursor.close()
+        finally:
+            conn.close()
+
+    def _schedule_table_exists(self, config_path: str) -> bool:
+        db_args = self._db_args_from_config(config_path)
+        conn = connect(**db_args)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = %s",
+                (self._SCHEDULE_TABLE,),
+            )
+            row = cursor.fetchone()
+            cursor.close()
+            return row is not None
+        finally:
+            conn.close()
+
     def _count_schedules(self, config_path: str, user_id: str) -> int:
         db_args = self._db_args_from_config(config_path)
         conn = connect(**db_args)
@@ -482,6 +517,68 @@ class TestDeleteUserE2E(BaseSynapseE2ETest):
                 },
             )
             self.assertNotEqual(login_response.status_code, 200)
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    async def test_scheduled_delete_for_missing_user_stops_retrying(self):
+        """Schedule for an already-deleted user must fail terminally, not retry forever.
+
+        Regression test for the staging incident where a schedule for a user
+        whose row was already gone retried every processor interval for days
+        with "404: No row found (users)".
+        """
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config={
+                    "delete_user_processor_interval_seconds": 1,
+                }
+            )
+
+            # Wait for the background processor loop to create the schedule
+            # table, then plant a due schedule for a user that does not exist.
+            for _ in range(30):
+                if self._schedule_table_exists(config_path):
+                    break
+                await asyncio.sleep(1)
+            else:
+                self.fail("Schedule table was never created")
+
+            ghost_user_id = "@ghostuser:my.domain.name"
+            self._insert_schedule(config_path, ghost_user_id, execute_at_ms=1)
+            self.assertEqual(self._count_schedules(config_path, ghost_user_id), 1)
+
+            # The schedule must be dropped as terminally failed. Without
+            # bounded retries the row is re-inserted every cycle forever.
+            for _ in range(30):
+                if self._count_schedules(config_path, ghost_user_id) == 0:
+                    break
+                await asyncio.sleep(1)
+            else:
+                self.fail("Schedule for missing user was still being retried")
+
+            # It must stay gone across further processor cycles (i.e. it was
+            # not re-inserted by another retry).
+            await asyncio.sleep(3)
+            self.assertEqual(self._count_schedules(config_path, ghost_user_id), 0)
         finally:
             self.stop_synapse(
                 server_process=server_process,

--- a/tests/test_delete_user_unit.py
+++ b/tests/test_delete_user_unit.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from synapse.api.errors import StoreError
+
+from synapse_pangea_chat.config import PangeaChatConfig
+from synapse_pangea_chat.delete_user.delete_user import (
+    MAX_SCHEDULE_ATTEMPTS,
+    DeleteUser,
+)
+
+LOGGER_NAME = "synapse.module.synapse_pangea_chat.delete_user"
+
+
+def _make_handler() -> DeleteUser:
+    api = MagicMock()
+    api._hs.hostname = "my.domain.name"
+    clock = MagicMock()
+    clock.time_msec.return_value = 1_000_000
+    api._hs.get_clock.return_value = clock
+    handler = DeleteUser(api, PangeaChatConfig())
+    handler._ensure_schedule_table = AsyncMock()  # type: ignore[method-assign]
+    handler._upsert_schedule = AsyncMock()  # type: ignore[method-assign]
+    handler._delete_user_now = AsyncMock()  # type: ignore[method-assign]
+    return handler
+
+
+def _schedule(
+    user_id: str = "@ghost:my.domain.name",
+    requested_by: str = "@requester:my.domain.name",
+    attempts: int = 0,
+) -> dict:
+    return {
+        "user_id": user_id,
+        "requested_by": requested_by,
+        "requested_by_admin": False,
+        "attempts": attempts,
+    }
+
+
+class TestProcessScheduledDeletesRetries(unittest.IsolatedAsyncioTestCase):
+    async def test_success_does_not_reschedule(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule()])
+
+        await handler._process_scheduled_deletes()
+
+        handler._delete_user_now.assert_awaited_once()
+        handler._upsert_schedule.assert_not_awaited()
+
+    async def test_transient_failure_reschedules_with_incremented_attempts(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule(attempts=1)])
+        handler._delete_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_deletes()
+
+        handler._upsert_schedule.assert_awaited_once()
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["user_id"], "@ghost:my.domain.name")
+        self.assertEqual(kwargs["attempts"], 2)
+
+    async def test_transient_failure_preserves_original_requester(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule()])
+        handler._delete_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_deletes()
+
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["requested_by"], "@requester:my.domain.name")
+
+    async def test_transient_failure_stops_after_max_attempts(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(
+            return_value=[_schedule(attempts=MAX_SCHEDULE_ATTEMPTS - 1)]
+        )
+        handler._delete_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with self.assertLogs(LOGGER_NAME, level="ERROR") as logs:
+            await handler._process_scheduled_deletes()
+
+        handler._upsert_schedule.assert_not_awaited()
+        self.assertTrue(any("giving up" in line for line in logs.output))
+        self.assertTrue(any("@ghost:my.domain.name" in line for line in logs.output))
+
+    async def test_user_not_found_fails_terminally_on_first_attempt(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule(attempts=0)])
+        handler._delete_user_now = AsyncMock(
+            side_effect=StoreError(404, "No row found (users)")
+        )
+
+        with self.assertLogs(LOGGER_NAME, level="ERROR") as logs:
+            await handler._process_scheduled_deletes()
+
+        handler._upsert_schedule.assert_not_awaited()
+        self.assertTrue(any("giving up" in line for line in logs.output))
+
+    async def test_missing_attempts_defaults_to_zero(self):
+        handler = _make_handler()
+        schedule = _schedule()
+        del schedule["attempts"]
+        handler._claim_due_schedules = AsyncMock(return_value=[schedule])
+        handler._delete_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_deletes()
+
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["attempts"], 1)
+
+    async def test_failure_on_one_schedule_does_not_block_others(self):
+        handler = _make_handler()
+        failing = _schedule(user_id="@ghost:my.domain.name")
+        succeeding = _schedule(user_id="@alive:my.domain.name")
+        handler._claim_due_schedules = AsyncMock(return_value=[failing, succeeding])
+        handler._delete_user_now = AsyncMock(
+            side_effect=[RuntimeError("boom"), {"ok": 1}]
+        )
+
+        await handler._process_scheduled_deletes()
+
+        self.assertEqual(handler._delete_user_now.await_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_courses_language_filter_e2e.py
+++ b/tests/test_public_courses_language_filter_e2e.py
@@ -20,9 +20,7 @@ from tests.base_e2e import BaseSynapseE2ETest
 from tests.mock_cms_server import MockCmsServer
 
 COURSE_PLAN_EVENT_TYPE = "pangea.course_plan"
-PUBLIC_COURSES_URL = (
-    "http://localhost:8008/_synapse/client/pangea/v1/public_courses"
-)
+PUBLIC_COURSES_URL = "http://localhost:8008/_synapse/client/pangea/v1/public_courses"
 
 
 class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
@@ -49,9 +47,7 @@ class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
         self.assertEqual(response.status_code, 200)
         return response.json()["room_id"]
 
-    def _get_courses(
-        self, access_token: str, **params: str
-    ) -> Dict[str, Any]:
+    def _get_courses(self, access_token: str, **params: str) -> Dict[str, Any]:
         response = requests.get(
             PUBLIC_COURSES_URL,
             params={"limit": "20", **params},
@@ -127,9 +123,7 @@ class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
                 f"target_language=es should match l2 es AND es-ES; got "
                 f"{titles(filtered)}",
             )
-            languages = sorted(
-                c["target_language"] for c in filtered["chunk"]
-            )
+            languages = sorted(c["target_language"] for c in filtered["chunk"])
             self.assertEqual(languages, ["es", "es-ES"])
 
             # Regional filter also matches across the base language.
@@ -139,9 +133,7 @@ class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
             # A different language stays excluded.
             french = self._get_courses(access_token, target_language="fr")
             self.assertEqual(len(french["chunk"]), 1)
-            self.assertEqual(
-                french["chunk"][0]["target_language"], "fr"
-            )
+            self.assertEqual(french["chunk"][0]["target_language"], "fr")
         finally:
             mock_cms.stop()
             self.stop_synapse(


### PR DESCRIPTION
## What

Bound scheduled account-deletion retries: persist a per-schedule attempt counter, stop permanently after 5 failed attempts, and fail 404s (user row already gone) terminally on the first attempt.

## Why

Closes #140. On staging, a scheduled delete for an already-deleted user retried every processor cycle for 2+ days with `404: No row found (users)`.

Retry/terminal-failure design lives in `.github/instructions/delete-user-export-user-data.instructions.md` (Scheduling Behavior), updated in this PR.

## What changed

- `synapse_pangea_chat/delete_user/delete_user.py`
  - `attempts` column on `pangea_delete_user_schedule` (in-place `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migrates existing installs)
  - `_process_scheduled_deletes` failure path: increment attempts; terminal after `MAX_SCHEDULE_ATTEMPTS = 5` or immediately on a 404 `SynapseError`; one final ERROR log with user id and terminal reason; retries now log at WARNING with attempt count
  - Retries preserve the original `requested_by` instead of overwriting it with the target user id
- Rides along: fixes the two pre-existing codestyle violations on main (black on `tests/test_public_courses_language_filter_e2e.py`, ruff import order in `synapse_pangea_chat/room_code/knock_with_code.py`) that were failing the CI `check_codestyle` gate (separate commit, mechanical only)

## Testing

- New unit tests `tests/test_delete_user_unit.py`: 7 passed (retry increment, max-attempts terminal, 404 terminal, requester preserved, multi-schedule isolation)
- Integration `tests/test_delete_user_e2e.py`: 7 tests, includes new regression test `test_scheduled_delete_for_missing_user_stops_retrying` (plants a due schedule for a nonexistent user, asserts it is dropped and stays dropped). Note: `test_delete_user_succeeds_when_cms_unavailable` flaked once on user registration in the batch run and passes standalone; unrelated to this change
- Style-touched suites `tests/test_public_courses_language_filter_e2e.py` + `tests/test_room_code_e2e.py`: 8 passed
- `black --check`, `ruff check`, `mypy synapse_pangea_chat tests`: all clean

## Deploy Notes

None. Deploys with the normal Ansible Synapse process; the schema migration is self-applying at module runtime, no one-time script or ordering constraint. The stuck staging schedule row for @wcjord will terminate on its next processing cycle after deploy (404 path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled user deletions now retry failed attempts up to five times before stopping.
  * Deletions for users who no longer exist stop immediately instead of retrying.
  * Retry scheduling preserves the original request details.
  * A failure affecting one scheduled deletion no longer prevents other pending deletions from being processed.

* **Tests**
  * Added coverage for retry limits, missing users, scheduling behavior, and processing multiple pending deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->