### PR TITLE
fix(export_user_data): bound scheduled export retries and fail 404s terminally

### DIFF
--- a/.github/instructions/delete-user-export-user-data.instructions.md
+++ b/.github/instructions/delete-user-export-user-data.instructions.md
@@ -36,7 +36,7 @@ Two admin-adjacent Pangea endpoints extend Synapse with controlled account lifec
 - Scheduled work is processed asynchronously on a recurring background loop.
 - The scheduling mechanism must preserve existing behavior across supported Synapse versions, including short test-time intervals.
 - Repeated force runs should be idempotent at the API contract level: callers receive a successful operation rather than a route-level failure when the feature is enabled.
-- Delete retries are bounded, never infinite. Each delete schedule persists an attempt counter; after a small fixed number of failed attempts (5) the schedule is dropped as terminally failed with one final error log naming the user and the terminal reason. Failures that can never succeed on retry (a 404: the user row is already gone) terminate the schedule on the first attempt. A terminally failed schedule holds no state — a fresh `schedule` or `force` request starts over cleanly.
+- Retries are bounded, never infinite — for both delete and export. Each schedule persists an attempt counter; after a small fixed number of failed attempts (5) the schedule is dropped as terminally failed with one final error log naming the user and the terminal reason. Failures that can never succeed on retry (a 404: the user row is already gone) terminate the schedule on the first attempt. A terminally failed schedule holds no state — a fresh `schedule` or `force` request starts over cleanly.
 
 ## Side Effects
 

--- a/synapse_pangea_chat/export_user_data/export_user_data.py
+++ b/synapse_pangea_chat/export_user_data/export_user_data.py
@@ -39,6 +39,11 @@ logger = logging.getLogger("synapse.module.synapse_pangea_chat.export_user_data"
 SCHEDULE_TABLE = "pangea_export_user_data_schedule"
 VALID_ACTIONS = {"schedule", "cancel", "force", "status"}
 CMS_AUTH_COLLECTION = "service-users"
+
+# A scheduled export is retried at most this many times before the schedule
+# is dropped as terminally failed.
+MAX_SCHEDULE_ATTEMPTS = 5
+
 _RUN_AS_BG_SUPPORTS_SERVER_NAME = (
     "server_name" in inspect.signature(run_as_background_process).parameters
 )
@@ -678,8 +683,17 @@ class ExportUserData(Resource):
                     execute_at_ms BIGINT NOT NULL,
                     requested_at_ms BIGINT NOT NULL,
                     requested_by TEXT NOT NULL,
-                    requested_by_admin BOOLEAN NOT NULL DEFAULT FALSE
+                    requested_by_admin BOOLEAN NOT NULL DEFAULT FALSE,
+                    attempts INTEGER NOT NULL DEFAULT 0
                 )
+                """
+            )
+            # Migrate pre-existing installs that created the table without
+            # the attempts column.
+            txn.execute(
+                f"""
+                ALTER TABLE {SCHEDULE_TABLE}
+                ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0
                 """
             )
             txn.execute(
@@ -701,19 +715,22 @@ class ExportUserData(Resource):
         execute_at_ms: int,
         requested_by: str,
         requested_by_admin: bool,
+        attempts: int = 0,
     ) -> None:
         def _upsert(txn: Any) -> None:
             txn.execute(
                 f"""
                 INSERT INTO {SCHEDULE_TABLE}
-                    (user_id, execute_at_ms, requested_at_ms, requested_by, requested_by_admin)
-                VALUES (%s, %s, %s, %s, %s)
+                    (user_id, execute_at_ms, requested_at_ms, requested_by,
+                     requested_by_admin, attempts)
+                VALUES (%s, %s, %s, %s, %s, %s)
                 ON CONFLICT (user_id)
                 DO UPDATE SET
                     execute_at_ms = EXCLUDED.execute_at_ms,
                     requested_at_ms = EXCLUDED.requested_at_ms,
                     requested_by = EXCLUDED.requested_by,
-                    requested_by_admin = EXCLUDED.requested_by_admin
+                    requested_by_admin = EXCLUDED.requested_by_admin,
+                    attempts = EXCLUDED.attempts
                 """,
                 (
                     user_id,
@@ -721,6 +738,7 @@ class ExportUserData(Resource):
                     self._clock.time_msec(),
                     requested_by,
                     requested_by_admin,
+                    attempts,
                 ),
             )
 
@@ -774,13 +792,19 @@ class ExportUserData(Resource):
                 f"""
                 DELETE FROM {SCHEDULE_TABLE}
                 WHERE execute_at_ms <= %s
-                RETURNING user_id, requested_by_admin
+                RETURNING user_id, requested_by, requested_by_admin, attempts
                 """,
                 (now_ms,),
             )
             rows = txn.fetchall()
             return [
-                {"user_id": row[0], "requested_by_admin": bool(row[1])} for row in rows
+                {
+                    "user_id": row[0],
+                    "requested_by": row[1],
+                    "requested_by_admin": bool(row[2]),
+                    "attempts": int(row[3] or 0),
+                }
+                for row in rows
             ]
 
         return await self._datastores.main.db_pool.runInteraction(
@@ -798,12 +822,32 @@ class ExportUserData(Resource):
             try:
                 await self._export_user_now(user_id)
             except Exception as e:
-                logger.error(
-                    "Failed to process scheduled export for %s: %s",
+                attempts = int(schedule.get("attempts") or 0) + 1
+                # A 404 means the user row is already gone; retrying can
+                # never succeed, so fail the schedule immediately.
+                permanently_failed = isinstance(e, SynapseError) and e.code == 404
+                if permanently_failed or attempts >= MAX_SCHEDULE_ATTEMPTS:
+                    logger.error(
+                        "Scheduled export for %s failed terminally after "
+                        "%d attempt(s) (%s), giving up: %s",
+                        user_id,
+                        attempts,
+                        (
+                            "permanent error"
+                            if permanently_failed
+                            else "max attempts reached"
+                        ),
+                        e,
+                    )
+                    continue
+                logger.warning(
+                    "Failed to process scheduled export for %s "
+                    "(attempt %d of %d), will retry: %s",
                     user_id,
+                    attempts,
+                    MAX_SCHEDULE_ATTEMPTS,
                     e,
                 )
-                # Re-schedule for retry
                 retry_at_ms = (
                     self._clock.time_msec()
                     + self._config.export_user_data_processor_interval_seconds * 1000
@@ -811,8 +855,9 @@ class ExportUserData(Resource):
                 await self._upsert_schedule(
                     user_id=user_id,
                     execute_at_ms=retry_at_ms,
-                    requested_by=user_id,
+                    requested_by=schedule.get("requested_by") or user_id,
                     requested_by_admin=bool(schedule["requested_by_admin"]),
+                    attempts=attempts,
                 )
 
 

--- a/tests/test_export_user_data_unit.py
+++ b/tests/test_export_user_data_unit.py
@@ -1,8 +1,12 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+from synapse.api.errors import StoreError
 
 import synapse_pangea_chat.export_user_data.export_user_data as export_module
+from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.export_user_data.export_user_data import (
+    MAX_SCHEDULE_ATTEMPTS,
     ExportUserData,
     JsonExfiltrationWriter,
     _background_process_args,
@@ -10,6 +14,34 @@ from synapse_pangea_chat.export_user_data.export_user_data import (
     _media_type_to_ext,
 )
 from tests.mock_cms_server import _parse_multipart_export_body
+
+LOGGER_NAME = "synapse.module.synapse_pangea_chat.export_user_data"
+
+
+def _make_handler() -> ExportUserData:
+    api = MagicMock()
+    api._hs.hostname = "my.domain.name"
+    clock = MagicMock()
+    clock.time_msec.return_value = 1_000_000
+    api._hs.get_clock.return_value = clock
+    handler = ExportUserData(api, PangeaChatConfig())
+    handler._ensure_schedule_table = AsyncMock()  # type: ignore[method-assign]
+    handler._upsert_schedule = AsyncMock()  # type: ignore[method-assign]
+    handler._export_user_now = AsyncMock()  # type: ignore[method-assign]
+    return handler
+
+
+def _schedule(
+    user_id: str = "@ghost:my.domain.name",
+    requested_by: str = "@requester:my.domain.name",
+    attempts: int = 0,
+) -> dict:
+    return {
+        "user_id": user_id,
+        "requested_by": requested_by,
+        "requested_by_admin": False,
+        "attempts": attempts,
+    }
 
 
 class TestJsonExfiltrationWriter(unittest.TestCase):
@@ -186,3 +218,86 @@ class TestMultipartCmsUploadContract(unittest.TestCase):
         )
 
         self.assertIsNone(parsed)
+
+
+class TestProcessScheduledExportsRetries(unittest.IsolatedAsyncioTestCase):
+    async def test_success_does_not_reschedule(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule()])
+
+        await handler._process_scheduled_exports()
+
+        handler._export_user_now.assert_awaited_once()
+        handler._upsert_schedule.assert_not_awaited()
+
+    async def test_transient_failure_reschedules_with_incremented_attempts(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule(attempts=1)])
+        handler._export_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_exports()
+
+        handler._upsert_schedule.assert_awaited_once()
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["user_id"], "@ghost:my.domain.name")
+        self.assertEqual(kwargs["attempts"], 2)
+
+    async def test_transient_failure_preserves_original_requester(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule()])
+        handler._export_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_exports()
+
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["requested_by"], "@requester:my.domain.name")
+
+    async def test_transient_failure_stops_after_max_attempts(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(
+            return_value=[_schedule(attempts=MAX_SCHEDULE_ATTEMPTS - 1)]
+        )
+        handler._export_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with self.assertLogs(LOGGER_NAME, level="ERROR") as logs:
+            await handler._process_scheduled_exports()
+
+        handler._upsert_schedule.assert_not_awaited()
+        self.assertTrue(any("giving up" in line for line in logs.output))
+        self.assertTrue(any("@ghost:my.domain.name" in line for line in logs.output))
+
+    async def test_user_not_found_fails_terminally_on_first_attempt(self):
+        handler = _make_handler()
+        handler._claim_due_schedules = AsyncMock(return_value=[_schedule(attempts=0)])
+        handler._export_user_now = AsyncMock(
+            side_effect=StoreError(404, "No row found (users)")
+        )
+
+        with self.assertLogs(LOGGER_NAME, level="ERROR") as logs:
+            await handler._process_scheduled_exports()
+
+        handler._upsert_schedule.assert_not_awaited()
+        self.assertTrue(any("giving up" in line for line in logs.output))
+
+    async def test_missing_attempts_defaults_to_zero(self):
+        handler = _make_handler()
+        schedule = _schedule()
+        del schedule["attempts"]
+        handler._claim_due_schedules = AsyncMock(return_value=[schedule])
+        handler._export_user_now = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await handler._process_scheduled_exports()
+
+        kwargs = handler._upsert_schedule.await_args.kwargs
+        self.assertEqual(kwargs["attempts"], 1)
+
+    async def test_failure_on_one_schedule_does_not_block_others(self):
+        handler = _make_handler()
+        failing = _schedule(user_id="@ghost:my.domain.name")
+        succeeding = _schedule(user_id="@alive:my.domain.name")
+        handler._claim_due_schedules = AsyncMock(return_value=[failing, succeeding])
+        handler._export_user_now = AsyncMock(side_effect=[RuntimeError("boom"), None])
+
+        await handler._process_scheduled_exports()
+
+        self.assertEqual(handler._export_user_now.await_count, 2)


### PR DESCRIPTION
## What

Bound scheduled user-data-export retries: persist a per-schedule attempt counter, stop permanently after 5 failed attempts, and fail 404s (user row already gone) terminally on the first attempt.

## Why

Closes #142. `_process_scheduled_exports` had the same infinite-retry pattern fixed for deletes in #141: any failure re-upserted the schedule with a new `execute_at_ms` forever, with no attempt cap. Latent bug found while fixing #141; no export incident observed yet, fixing preventively.

Retry/terminal-failure design lives in `.github/instructions/delete-user-export-user-data.instructions.md` (Scheduling Behavior), generalized in this PR to cover export as well as delete.

## What changed

- `synapse_pangea_chat/export_user_data/export_user_data.py`
  - `attempts` column on `pangea_export_user_data_schedule` (in-place `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migrates existing installs)
  - `_process_scheduled_exports` failure path: increment attempts; terminal after `MAX_SCHEDULE_ATTEMPTS = 5` or immediately on a 404 `SynapseError`; one final ERROR log with user id and terminal reason; retries now log at WARNING with attempt count
  - Retries preserve the original `requested_by` instead of overwriting it with the target user id
- Mirrors the merged delete fix (#141) exactly, in the same style.

## Testing

- New unit tests `tests/test_export_user_data_unit.py::TestProcessScheduledExportsRetries` (mirrors `tests/test_delete_user_unit.py`): 7 passed (retry increment, max-attempts terminal, 404 terminal, requester preserved, multi-schedule isolation)
- Full unit runs of `tests/test_export_user_data_unit.py` + `tests/test_delete_user_unit.py`: 32 passed
- Integration `tests/test_export_user_data_e2e.py` (real Synapse + PostgreSQL; exercises the new schema, migration, upsert, and claim queries): 18 passed
- `black --check`, `ruff check`, `mypy synapse_pangea_chat tests`: all clean

## Deploy Notes

None. Deploys with the normal Ansible Synapse process; the schema migration is self-applying at module runtime, no one-time script or ordering constraint.