### PR TITLE
fix(tests): satisfy mypy so main goes green again

### DIFF
--- a/tests/test_public_courses_backfill_l2_unit.py
+++ b/tests/test_public_courses_backfill_l2_unit.py
@@ -68,7 +68,7 @@ def _make_backfill(
     # Only sender *selection* is stubbed; the real _write_repair builds and
     # sends the event, so the content under assertion is the content the
     # module would really write.
-    backfill._select_state_sender = AsyncMock(  # type: ignore[attr-defined]
+    backfill._select_state_sender = AsyncMock(  # type: ignore[method-assign]
         return_value=sender
     )
 

--- a/tests/test_public_courses_language_filter_e2e.py
+++ b/tests/test_public_courses_language_filter_e2e.py
@@ -38,7 +38,7 @@ class TestPublicCoursesLanguageFilterE2E(BaseSynapseE2ETest):
         the catalog does not check.
         """
         headers = {"Authorization": f"Bearer {access_token}"}
-        initial_state = []
+        initial_state: List[Dict[str, Any]] = []
         if plan_content is not None:
             initial_state.append(
                 {


### PR DESCRIPTION
## What

Two type errors, two lines. `main` is currently red on `Check types with Mypy`; this makes it green.

- `tests/test_public_courses_backfill_l2_unit.py:71` — `Cannot assign to a method [method-assign]`. The existing suppression named `attr-defined`, which is not the code mypy actually raises for assigning over a real method. Corrected to `method-assign`.
- `tests/test_public_courses_language_filter_e2e.py:41` — `initial_state = []` was inferred as `list[dict[str, Collection[str]]]` from its one `append`, which is not assignable to `requests`' JSON parameter type. Annotated `List[Dict[str, Any]]`.

## Why

Both landed with #144, whose `Linting` run failed and was merged anyway — my mistake. Everything branched off `main` since has inherited a red rollup it cannot fix from inside its own diff, because `tox.ini` scopes mypy to `synapse_pangea_chat tests` and the follow-up work is in `scripts/`. pangeachat/synapse-pangea-chat#145 is blocked behind exactly this.

Test-only. No production code, no behavior change.

## Testing

- `mypy synapse_pangea_chat tests` → `Success: no issues found in 113 source files` (was 2 errors).
- `python -m unittest tests.test_public_courses_backfill_l2_unit` → 24 tests OK.
- `black --check` clean on both files.

## Deploy Notes

None.