### PR TITLE
fix(create_course_space): env-correct short-code admin join URL

### DIFF
--- a/synapse_pangea_chat/email_invite/create_course_space.py
+++ b/synapse_pangea_chat/email_invite/create_course_space.py
@@ -88,6 +88,19 @@ def build_course_plan_content(
     return content
 
 
+def build_admin_join_url(app_base_url: str, access_code: str) -> str:
+    """Admin join link for a newly created course space.
+
+    The external form is the CloudFront short code ``<app>/<code>`` — a 302 to
+    the client's ``/join_with_link?classcode=`` route, which the client is the
+    sole producer of (see deep-linking.instructions.md). Built on the
+    environment's app host from ``app_base_url`` (ansible sets it per env:
+    ``app.pangea.chat`` in prod, ``app.staging.pangea.chat`` on staging), never
+    a hardcoded host — a staging course must not hand out a prod link.
+    """
+    return f"{app_base_url.rstrip('/')}/{access_code}"
+
+
 class CreateCourseSpace(Resource):
     isLeaf = True
 
@@ -233,10 +246,9 @@ class CreateCourseSpace(Resource):
                 except Exception as e:
                     logger.warning(f"Failed to set room avatar: {e}")
 
-            # Build admin join URL (same format the client uses for class links)
-            admin_join_url = (
-                f"https://pangea.chat/#/join_with_link?classcode={admin_code}"
-            )
+            # Build admin join URL — short code on the env's app host, never a
+            # hardcoded host (see build_admin_join_url).
+            admin_join_url = build_admin_join_url(self._config.app_base_url, admin_code)
 
             # TODO: Send invite email to teacher via invite_by_email
             # (placeholder — invite_by_email endpoint is a separate session)

--- a/tests/test_create_course_space_unit.py
+++ b/tests/test_create_course_space_unit.py
@@ -12,6 +12,7 @@ import unittest
 from typing import Any
 
 from synapse_pangea_chat.email_invite.create_course_space import (
+    build_admin_join_url,
     build_course_plan_content,
 )
 from synapse_pangea_chat.public_courses.get_public_courses import (
@@ -134,6 +135,39 @@ class TestCatalogReadsWhatWeWrite(unittest.TestCase):
         content = build_course_plan_content("", "es")
 
         self.assertIsNone(extract_plan_id(content))
+
+
+class TestBuildAdminJoinUrl(unittest.TestCase):
+    def test_uses_the_configured_app_host_not_a_hardcoded_one(self) -> None:
+        """The host follows ``app_base_url`` (ansible sets it per env).
+
+        The bug this pins: a hardcoded ``pangea.chat`` handed every staging
+        course a production join link. Staging config resolves to the staging
+        app host and prod to the prod one.
+        """
+        self.assertEqual(
+            build_admin_join_url("https://app.staging.pangea.chat", "04wpy5e"),
+            "https://app.staging.pangea.chat/04wpy5e",
+        )
+        self.assertEqual(
+            build_admin_join_url("https://app.pangea.chat", "abc123x"),
+            "https://app.pangea.chat/abc123x",
+        )
+
+    def test_emits_the_short_code_form_not_the_classcode_route(self) -> None:
+        """External form is ``<app>/<code>`` — the CloudFront 302 source — not
+        the client's internal ``/#/join_with_link?classcode=`` spelling."""
+        url = build_admin_join_url("https://app.pangea.chat", "xyz789q")
+
+        self.assertNotIn("join_with_link", url)
+        self.assertNotIn("classcode", url)
+        self.assertTrue(url.endswith("/xyz789q"))
+
+    def test_trailing_slash_on_base_is_not_doubled(self) -> None:
+        self.assertEqual(
+            build_admin_join_url("https://app.pangea.chat/", "code42x"),
+            "https://app.pangea.chat/code42x",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`create_course_space` returned an `admin_join_url` of the form
`https://pangea.chat/#/join_with_link?classcode=<code>` — hardcoded. Three defects:

1. **`pangea.chat`** is the marketing host, not the app host (`app.*`).
2. **Always production** — a course created on staging handed out a prod link.
3. **Raw internal route shape** (`/#/join_with_link?classcode=`) instead of the external short code.

## Fix

Extract a pure `build_admin_join_url(app_base_url, code)` returning `<app>/<code>`:

- **Host** from `self._config.app_base_url` — ansible already wires this per env
  (`app.pangea.chat` prod, `app.staging.pangea.chat` staging), same source `invite_by_email` uses.
- **Shape** is the CloudFront short code (the 302 source), per the org deep-linking contract.

3 unit tests added (host-follows-config, short-code-not-classcode, no double slash). Full unit suite green; black + ruff clean.

## Needs one-time deploy

Synapse deploys via ansible, not push-to-main. No config/schema change — code only.

## Follow-up flagged (not in this PR)

The short-code shape now differs from what two other places still describe:
- `create-course-space.instructions.md` and client `joining-courses.instructions.md` Route 1 both document the `?classcode=` form as the class link.
- `invite_by_email` still emits `{app_base_url}/#/join_with_link?classcode=`.

Reconciling the producer contract to short-code across both endpoints + the docs, and verifying mobile (Universal Links / the `web/index.html` bypass keyed on `join_with_link`) handle the bare short code, is a separate reviewed change.