### PR TITLE
feat: add activity_session_previews module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "aiounittest",
   "aiohttp",
   "psycopg2",
+  "requests",
   "testing.postgresql",
   # for type checking
   "mypy == 1.6.1",

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi
 
+from synapse_pangea_chat.activity_session_previews import ActivitySessionPreviews
 from synapse_pangea_chat.assign_room_membership import AssignRoomMembership
 from synapse_pangea_chat.config import PangeaChatConfig
 from synapse_pangea_chat.delayed_push import configure_delayed_push
@@ -88,6 +89,15 @@ class PangeaChat:
         # Register reactive cache invalidation callback for room preview
         self._api.register_third_party_rules_callbacks(
             on_new_event=self._on_new_event_room_preview,
+        )
+
+        # --- Activity Session Previews ---
+        # Space-scoped session discovery: a thin front on the room_preview
+        # reader (shares its cache, invalidation, and rate limiter).
+        self.activity_session_previews_resource = ActivitySessionPreviews(api, config)
+        self._api.register_web_resource(
+            path="/_synapse/client/pangea/v1/activity_session_previews",
+            resource=self.activity_session_previews_resource,
         )
 
         # --- Room Code ---

--- a/synapse_pangea_chat/activity_session_previews/__init__.py
+++ b/synapse_pangea_chat/activity_session_previews/__init__.py
@@ -1,0 +1,7 @@
+from synapse_pangea_chat.activity_session_previews.activity_session_previews import (
+    ActivitySessionPreviews,
+)
+
+__all__ = [
+    "ActivitySessionPreviews",
+]

--- a/synapse_pangea_chat/activity_session_previews/activity_session_previews.py
+++ b/synapse_pangea_chat/activity_session_previews/activity_session_previews.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from synapse.api.errors import (
+    AuthError,
+    InvalidClientTokenError,
+    MissingClientTokenError,
+)
+from synapse.http import server
+from synapse.http.server import respond_with_json
+from synapse.http.site import SynapseRequest
+from synapse.module_api import ModuleApi
+from twisted.internet import defer
+from twisted.web.resource import Resource
+
+from synapse_pangea_chat.activity_session_previews.get_activity_session_previews import (
+    get_activity_session_previews,
+)
+from synapse_pangea_chat.room_preview.is_rate_limited import is_rate_limited
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger(
+    "synapse.module.synapse_pangea_chat.activity_session_previews"
+)
+
+
+class ActivitySessionPreviews(Resource):
+    """GET /_synapse/client/pangea/v1/activity_session_previews
+
+    Space-scoped session discovery: ?rooms is a comma-delimited list of course
+    space ids, ?activity an optional activity id filter. Responds with the same
+    shape as room_preview, for only the activity-session child rooms of the
+    spaces the caller is joined to. Shares room_preview's per-user rate
+    limiter. See activity-session-previews.instructions.md.
+    """
+
+    isLeaf = True
+
+    def __init__(self, api: ModuleApi, config: PangeaChatConfig):
+        super().__init__()
+        self._api = api
+        self._config = config
+        self._auth = self._api._hs.get_auth()
+        self._datastores = self._api._hs.get_datastores()
+
+    def render_GET(self, request: SynapseRequest):
+        defer.ensureDeferred(self._async_render_GET(request))
+        return server.NOT_DONE_YET
+
+    async def _async_render_GET(self, request: SynapseRequest):
+        try:
+            requester = await self._auth.get_user_by_req(request)
+            requester_id = requester.user.to_string()
+            if is_rate_limited(requester_id, self._config):
+                respond_with_json(
+                    request,
+                    429,
+                    {"error": "Rate limited"},
+                    send_cors=True,
+                )
+                return
+
+            # Parse the space ids from the query string (same CSV shape as
+            # room_preview's rooms param).
+            rooms_param = request.args.get(b"rooms")
+            space_ids = []
+            if rooms_param:
+                rooms_str = rooms_param[0].decode("utf-8")
+                space_ids = [
+                    space_id.strip()
+                    for space_id in rooms_str.split(",")
+                    if space_id.strip()
+                ]
+
+            if not space_ids:
+                # No spaces to answer for — same graceful empty response as
+                # room_preview with no rooms.
+                respond_with_json(
+                    request,
+                    200,
+                    {"rooms": {}},
+                    send_cors=True,
+                )
+                return
+
+            # Optional single-activity scope.
+            activity_param = request.args.get(b"activity")
+            activity_id = None
+            if activity_param:
+                activity_id = activity_param[0].decode("utf-8").strip() or None
+
+            rooms_data = await get_activity_session_previews(
+                space_ids,
+                activity_id,
+                requester_id,
+                self._api,
+                self._datastores.main,
+                self._config,
+            )
+
+            respond_with_json(
+                request,
+                200,
+                {"rooms": rooms_data},
+                send_cors=True,
+            )
+
+        except (AuthError, InvalidClientTokenError, MissingClientTokenError) as e:
+            logger.info(
+                "Authentication failed for activity session previews request: %s", e
+            )
+            respond_with_json(
+                request,
+                401,
+                {"error": "Unauthorized", "errcode": "M_UNAUTHORIZED"},
+                send_cors=True,
+            )
+        except Exception as e:
+            logger.error("Error processing request: %s", e)
+            respond_with_json(
+                request,
+                500,
+                {"error": "Internal server error"},
+                send_cors=True,
+            )

--- a/synapse_pangea_chat/activity_session_previews/get_activity_session_previews.py
+++ b/synapse_pangea_chat/activity_session_previews/get_activity_session_previews.py
@@ -1,0 +1,192 @@
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from synapse.module_api import ModuleApi
+from synapse.storage.databases.main.room import RoomStore
+
+from synapse_pangea_chat.room_preview.constants import (
+    MEMBERSHIP_JOIN,
+    PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE,
+)
+from synapse_pangea_chat.room_preview.get_room_preview import get_room_preview
+
+if TYPE_CHECKING:
+    from synapse_pangea_chat.config import PangeaChatConfig
+
+logger = logging.getLogger(
+    "synapse.module.synapse_pangea_chat.activity_session_previews"
+)
+
+# https://spec.matrix.org/v1.11/client-server-api/#mspacechild
+EVENT_TYPE_M_SPACE_CHILD = "m.space.child"
+
+
+def _placeholders(room_store: RoomStore, count: int) -> str:
+    """Build a parameter-placeholder list matching the active database engine
+    (sqlite uses ?, postgres uses %s) — same detection as get_room_preview."""
+    database_engine = room_store.db_pool.engine.module.__name__
+    return ",".join(["?" if "sqlite" in database_engine else "%s"] * count)
+
+
+def _has_valid_via(content: Any) -> bool:
+    """A live m.space.child link carries a non-empty list of server names in
+    content.via; a removed child's event has empty content (or an invalid via)
+    and must not resurface — mirrors synapse's own hierarchy filtering."""
+    if not isinstance(content, dict):
+        return False
+    via = content.get("via")
+    if not via or not isinstance(via, list):
+        return False
+    return all(isinstance(v, str) for v in via)
+
+
+async def _member_space_ids(
+    space_ids: List[str],
+    requester_id: str,
+    room_store: RoomStore,
+) -> List[str]:
+    """The subset of space_ids the requester is currently joined to. Non-member
+    spaces are dropped silently so one stale space id never sinks a batch."""
+    member_ids: List[str] = []
+    for space_id in space_ids:
+        try:
+            (
+                membership,
+                _,
+            ) = await room_store.get_local_current_membership_for_user_in_room(
+                requester_id, space_id
+            )
+        except Exception as e:
+            logger.warning(
+                "Membership lookup failed for %s in %s: %s", requester_id, space_id, e
+            )
+            continue
+        if membership == MEMBERSHIP_JOIN:
+            member_ids.append(space_id)
+    return member_ids
+
+
+async def _child_room_ids(
+    space_ids: List[str],
+    room_store: RoomStore,
+) -> List[str]:
+    """Direct m.space.child room ids across space_ids, excluding removed
+    children (no valid via) and the spaces themselves."""
+    if not space_ids:
+        return []
+
+    query = f"""
+        SELECT cse.room_id, cse.state_key, ej.json
+        FROM current_state_events cse
+        JOIN event_json ej ON cse.event_id = ej.event_id
+        WHERE
+            cse.room_id IN ({_placeholders(room_store, len(space_ids))})
+            AND cse.type = {_placeholders(room_store, 1)}
+        ORDER BY cse.room_id, cse.state_key
+    """
+    rows = await room_store.db_pool.execute(
+        "get_activity_session_preview_space_children",
+        query,
+        *space_ids,
+        EVENT_TYPE_M_SPACE_CHILD,
+    )
+
+    child_ids: List[str] = []
+    seen: set = set(space_ids)
+    for _, state_key, json_data in rows:
+        if not state_key or state_key in seen:
+            continue
+        event_data = json.loads(json_data) if isinstance(json_data, str) else json_data
+        content = event_data.get("content") if isinstance(event_data, dict) else None
+        if not _has_valid_via(content):
+            continue
+        seen.add(state_key)
+        child_ids.append(state_key)
+    return child_ids
+
+
+async def _activity_session_ids(
+    child_room_ids: List[str],
+    activity_id: Optional[str],
+    room_store: RoomStore,
+) -> List[str]:
+    """The child rooms that are activity sessions — rooms carrying a
+    pangea.activity_plan state event — optionally narrowed to one activity.
+
+    Queries the plan event type directly, independent of the config-driven
+    room_preview_state_event_types list, so a config-trimmed deploy can't
+    silently break session discovery.
+    """
+    if not child_room_ids:
+        return []
+
+    query = f"""
+        SELECT cse.room_id, ej.json
+        FROM current_state_events cse
+        JOIN event_json ej ON cse.event_id = ej.event_id
+        WHERE
+            cse.room_id IN ({_placeholders(room_store, len(child_room_ids))})
+            AND cse.type = {_placeholders(room_store, 1)}
+        ORDER BY cse.room_id
+    """
+    rows = await room_store.db_pool.execute(
+        "get_activity_session_preview_plans",
+        query,
+        *child_room_ids,
+        PANGEA_ACTIVITY_PLAN_STATE_EVENT_TYPE,
+    )
+
+    session_ids: List[str] = []
+    seen: set = set()
+    for room_id, json_data in rows:
+        if room_id in seen:
+            continue
+        if activity_id is not None:
+            event_data = (
+                json.loads(json_data) if isinstance(json_data, str) else json_data
+            )
+            content = (
+                event_data.get("content", {}) if isinstance(event_data, dict) else {}
+            )
+            if not isinstance(content, dict):
+                continue
+            if content.get("activity_id") != activity_id:
+                continue
+        seen.add(room_id)
+        session_ids.append(room_id)
+    return session_ids
+
+
+async def get_activity_session_previews(
+    space_ids: List[str],
+    activity_id: Optional[str],
+    requester_id: str,
+    api: ModuleApi,
+    room_store: RoomStore,
+    config: "PangeaChatConfig",
+) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """
+    Preview data for the activity-session rooms under the requester's joined
+    course spaces, in the same shape as get_room_preview (room_id ->
+    state_event_type -> state_key -> event JSON, plus membership_summary).
+
+    A thin front on the room_preview reader: resolve each space's direct
+    children, gate on the requester's space membership, keep the children
+    carrying a pangea.activity_plan (optionally one activity's), then hand the
+    survivors to get_room_preview — inheriting its projection, caching, and
+    invalidation. See activity-session-previews.instructions.md.
+
+    :param space_ids: Course-space room ids the caller asks about.
+    :param activity_id: Optional activity id to narrow the sessions to.
+    :param requester_id: The authenticated caller; non-member spaces drop.
+    :param api: ModuleApi, passed through to get_room_preview.
+    :param room_store: Main datastore for the child/plan/membership queries.
+    :param config: Module config (preview state event types, rate limits).
+    """
+    member_ids = await _member_space_ids(space_ids, requester_id, room_store)
+    child_ids = await _child_room_ids(member_ids, room_store)
+    session_ids = await _activity_session_ids(child_ids, activity_id, room_store)
+    if not session_ids:
+        return {}
+    return await get_room_preview(session_ids, api, room_store, config)

--- a/tests/test_activity_session_previews_e2e.py
+++ b/tests/test_activity_session_previews_e2e.py
@@ -1,0 +1,273 @@
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_e2e import BaseSynapseE2ETest
+
+logger = logging.getLogger(__name__)
+
+MODULE_CONFIG = {
+    "room_preview_state_event_types": [
+        "pangea.activity_plan",
+        "pangea.activity_roles",
+    ],
+    # The suite makes more GETs than the default 10-per-burst allows.
+    "room_preview_requests_per_burst": 1000,
+}
+
+# The many-children scenario creates well over the old client-side hierarchy
+# page size in rooms; lift the message ratelimits so setup isn't throttled.
+SYNAPSE_CONFIG_OVERRIDES = {
+    "rc_message": {"per_second": 1000, "burst_count": 100000},
+    "rc_joins": {
+        "local": {"per_second": 1000, "burst_count": 100000},
+        "remote": {"per_second": 1000, "burst_count": 100000},
+    },
+}
+
+# Comfortably past the 100-room hierarchy page the old client-side discovery
+# was limited to (the pangeachat/client#7982 miss).
+MANY_CHILDREN_COUNT = 110
+
+
+class TestActivitySessionPreviewsE2E(BaseSynapseE2ETest):
+    async def test_activity_session_previews(self) -> None:
+        postgres = None
+        synapse_dir = None
+        server_process = None
+        stdout_thread = None
+        stderr_thread = None
+        try:
+            (
+                postgres,
+                synapse_dir,
+                config_path,
+                server_process,
+                stdout_thread,
+                stderr_thread,
+            ) = await self.start_test_synapse(
+                module_config=MODULE_CONFIG,
+                synapse_config_overrides=SYNAPSE_CONFIG_OVERRIDES,
+            )
+
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="member",
+                password="pw1",
+                admin=False,
+            )
+            await self.register_user(
+                config_path=config_path,
+                dir=synapse_dir,
+                user="outsider",
+                password="pw2",
+                admin=False,
+            )
+            member_id, member_token = await self.login_user("member", "pw1")
+            outsider_id, outsider_token = await self.login_user("outsider", "pw2")
+            self._server_name = member_id.split(":", 1)[1]
+
+            self.previews_url = (
+                f"{self.server_url}"
+                "/_synapse/client/pangea/v1/activity_session_previews"
+            )
+
+            # One space with a mixed set of children: two sessions for two
+            # different activities, a plain chat, and a removed session.
+            space_id = await self._create_space(member_token)
+            session_1 = await self._create_session_room(member_token, "act-1")
+            session_2 = await self._create_session_room(member_token, "act-2")
+            chat = await self.create_private_room(member_token)
+            removed = await self._create_session_room(member_token, "act-removed")
+            for child in (session_1, session_2, chat, removed):
+                self._add_child(member_token, space_id, child)
+            self._remove_child(member_token, space_id, removed)
+
+            await self._test_returns_only_session_children(
+                member_token, space_id, session_1, session_2, chat, removed
+            )
+            await self._test_activity_scope(
+                member_token, space_id, session_1, session_2
+            )
+            await self._test_preview_shape(member_token, space_id, session_1)
+            await self._test_non_member_space_dropped(outsider_token, space_id)
+            await self._test_mixed_membership_batch(
+                member_token, outsider_id, outsider_token, space_id, session_1
+            )
+            await self._test_no_rooms_param(member_token)
+            await self._test_many_children_all_found(member_token)
+
+        finally:
+            self.stop_synapse(
+                server_process=server_process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                synapse_dir=synapse_dir,
+                postgres=postgres,
+            )
+
+    # --- scenario helpers -------------------------------------------------
+
+    async def _test_returns_only_session_children(
+        self,
+        token: str,
+        space_id: str,
+        session_1: str,
+        session_2: str,
+        chat: str,
+        removed: str,
+    ) -> None:
+        """Sessions come back; the chat child, the removed session child, and
+        the space itself do not."""
+        rooms = self._get_previews(token, rooms=space_id)
+        self.assertEqual(set(rooms.keys()), {session_1, session_2})
+        self.assertNotIn(chat, rooms)
+        self.assertNotIn(removed, rooms)
+        self.assertNotIn(space_id, rooms)
+
+    async def _test_activity_scope(
+        self, token: str, space_id: str, session_1: str, session_2: str
+    ) -> None:
+        """?activity narrows to that activity's sessions only."""
+        rooms = self._get_previews(token, rooms=space_id, activity="act-1")
+        self.assertEqual(set(rooms.keys()), {session_1})
+
+        rooms = self._get_previews(token, rooms=space_id, activity="act-none")
+        self.assertEqual(rooms, {})
+
+    async def _test_preview_shape(
+        self, token: str, space_id: str, session_1: str
+    ) -> None:
+        """The per-room payload is room_preview's shape: event type ->
+        state key -> event JSON, with the activity plan projected to its
+        reference keys."""
+        rooms = self._get_previews(token, rooms=space_id)
+        plan_event = rooms[session_1]["pangea.activity_plan"]["default"]
+        self.assertEqual(plan_event["content"], {"activity_id": "act-1"})
+
+    async def _test_non_member_space_dropped(
+        self, outsider_token: str, space_id: str
+    ) -> None:
+        """A caller not joined to the space gets nothing for it — silently,
+        not an error."""
+        rooms = self._get_previews(outsider_token, rooms=space_id)
+        self.assertEqual(rooms, {})
+
+    async def _test_mixed_membership_batch(
+        self,
+        member_token: str,
+        outsider_id: str,
+        outsider_token: str,
+        member_only_space: str,
+        member_only_session: str,
+    ) -> None:
+        """In a batch mixing member and non-member spaces, only the member
+        spaces answer."""
+        shared_space = await self._create_space(member_token)
+        shared_session = await self._create_session_room(member_token, "act-shared")
+        self._add_child(member_token, shared_space, shared_session)
+        self.assertTrue(
+            await self.invite_user_to_room(shared_space, outsider_id, member_token)
+        )
+        self.assertTrue(await self.accept_room_invitation(shared_space, outsider_token))
+
+        rooms = self._get_previews(
+            outsider_token, rooms=f"{member_only_space},{shared_space}"
+        )
+        self.assertEqual(set(rooms.keys()), {shared_session})
+        self.assertNotIn(member_only_session, rooms)
+
+    async def _test_no_rooms_param(self, token: str) -> None:
+        response = requests.get(
+            self.previews_url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"rooms": {}})
+
+    async def _test_many_children_all_found(self, token: str) -> None:
+        """A space with more children than the old client-side hierarchy page
+        limit still returns every session — the #7982 regression, server-side.
+        The session is added last so it sits past any first 'page'."""
+        big_space = await self._create_space(token)
+        for _ in range(MANY_CHILDREN_COUNT):
+            chat = await self.create_private_room(token)
+            self._add_child(token, big_space, chat)
+        late_session = await self._create_session_room(token, "act-late")
+        self._add_child(token, big_space, late_session)
+
+        rooms = self._get_previews(token, rooms=big_space)
+        self.assertEqual(set(rooms.keys()), {late_session})
+
+    # --- request helpers --------------------------------------------------
+
+    def _get_previews(
+        self, token: str, *, rooms: str, activity: Optional[str] = None
+    ) -> Dict[str, Any]:
+        params: Dict[str, str] = {"rooms": rooms}
+        if activity is not None:
+            params["activity"] = activity
+        response = requests.get(
+            self.previews_url,
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["rooms"]
+
+    async def _create_space(self, token: str) -> str:
+        response = requests.post(
+            f"{self.server_url}/_matrix/client/v3/createRoom",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "visibility": "private",
+                "preset": "private_chat",
+                "creation_content": {"type": "m.space"},
+            },
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["room_id"]
+
+    async def _create_session_room(self, token: str, activity_id: str) -> str:
+        response = requests.post(
+            f"{self.server_url}/_matrix/client/v3/createRoom",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "visibility": "private",
+                "preset": "private_chat",
+                "initial_state": [
+                    {
+                        "type": "pangea.activity_plan",
+                        "state_key": "",
+                        "content": {"activity_id": activity_id},
+                    }
+                ],
+            },
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["room_id"]
+
+    def _put_child_state(
+        self, token: str, space_id: str, child_id: str, content: Dict[str, Any]
+    ) -> None:
+        response = requests.put(
+            f"{self.server_url}/_matrix/client/v3/rooms/{space_id}"
+            f"/state/m.space.child/{child_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json=content,
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def _add_child(self, token: str, space_id: str, child_id: str) -> None:
+        self._put_child_state(token, space_id, child_id, {"via": [self._server_name]})
+
+    def _remove_child(self, token: str, space_id: str, child_id: str) -> None:
+        # Removing a space child is writing an empty m.space.child event.
+        self._put_child_state(token, space_id, child_id, {})

--- a/tests/test_activity_session_previews_unit.py
+++ b/tests/test_activity_session_previews_unit.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any, List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from synapse_pangea_chat.activity_session_previews.get_activity_session_previews import (
+    _activity_session_ids,
+    _child_room_ids,
+    _has_valid_via,
+    _member_space_ids,
+    get_activity_session_previews,
+)
+
+USER = "@learner:my.domain.name"
+SPACE_A = "!spaceA:my.domain.name"
+SPACE_B = "!spaceB:my.domain.name"
+SESSION_1 = "!session1:my.domain.name"
+SESSION_2 = "!session2:my.domain.name"
+CHAT = "!chat:my.domain.name"
+
+
+def _room_store(
+    rows: Optional[List[Tuple[Any, ...]]] = None,
+    membership: Any = ("join", "$event"),
+) -> Any:
+    store = MagicMock()
+    engine_module = MagicMock()
+    engine_module.__name__ = "sqlite3"
+    store.db_pool.engine.module = engine_module
+    store.db_pool.execute = AsyncMock(return_value=rows or [])
+    store.get_local_current_membership_for_user_in_room = AsyncMock(
+        return_value=membership
+    )
+    return store
+
+
+def _child_row(space_id: str, child_id: str, content: Any) -> Tuple[str, str, str]:
+    return (space_id, child_id, json.dumps({"content": content}))
+
+
+def _plan_row(room_id: str, content: Any) -> Tuple[str, str]:
+    return (room_id, json.dumps({"content": content}))
+
+
+class TestHasValidVia(unittest.TestCase):
+    def test_valid_via_list(self) -> None:
+        self.assertTrue(_has_valid_via({"via": ["my.domain.name"]}))
+
+    def test_removed_child_empty_content(self) -> None:
+        self.assertFalse(_has_valid_via({}))
+
+    def test_non_dict_content(self) -> None:
+        self.assertFalse(_has_valid_via(None))
+
+    def test_empty_via(self) -> None:
+        self.assertFalse(_has_valid_via({"via": []}))
+
+    def test_via_not_a_list(self) -> None:
+        self.assertFalse(_has_valid_via({"via": "my.domain.name"}))
+
+    def test_via_with_non_string_entry(self) -> None:
+        self.assertFalse(_has_valid_via({"via": ["my.domain.name", 42]}))
+
+
+class TestChildRoomIds(unittest.IsolatedAsyncioTestCase):
+    async def test_keeps_valid_children_drops_removed_and_self(self) -> None:
+        store = _room_store(
+            rows=[
+                _child_row(SPACE_A, SESSION_1, {"via": ["my.domain.name"]}),
+                # Removed child: empty content must not resurface.
+                _child_row(SPACE_A, SESSION_2, {}),
+                # A space listing itself is skipped.
+                _child_row(SPACE_A, SPACE_A, {"via": ["my.domain.name"]}),
+                _child_row(SPACE_A, CHAT, {"via": ["my.domain.name"]}),
+            ]
+        )
+        result = await _child_room_ids([SPACE_A], store)
+        self.assertEqual(result, [SESSION_1, CHAT])
+
+    async def test_deduplicates_children_across_spaces(self) -> None:
+        store = _room_store(
+            rows=[
+                _child_row(SPACE_A, SESSION_1, {"via": ["my.domain.name"]}),
+                _child_row(SPACE_B, SESSION_1, {"via": ["my.domain.name"]}),
+            ]
+        )
+        result = await _child_room_ids([SPACE_A, SPACE_B], store)
+        self.assertEqual(result, [SESSION_1])
+
+    async def test_no_spaces_no_query(self) -> None:
+        store = _room_store()
+        self.assertEqual(await _child_room_ids([], store), [])
+        store.db_pool.execute.assert_not_awaited()
+
+
+class TestActivitySessionIds(unittest.IsolatedAsyncioTestCase):
+    async def test_unscoped_returns_every_room_with_a_plan(self) -> None:
+        store = _room_store(
+            rows=[
+                _plan_row(SESSION_1, {"activity_id": "act-1"}),
+                _plan_row(SESSION_2, {"activity_id": "act-2"}),
+            ]
+        )
+        result = await _activity_session_ids([SESSION_1, SESSION_2, CHAT], None, store)
+        self.assertEqual(result, [SESSION_1, SESSION_2])
+
+    async def test_scoped_keeps_only_the_matching_activity(self) -> None:
+        store = _room_store(
+            rows=[
+                _plan_row(SESSION_1, {"activity_id": "act-1"}),
+                _plan_row(SESSION_2, {"activity_id": "act-2"}),
+            ]
+        )
+        result = await _activity_session_ids([SESSION_1, SESSION_2], "act-2", store)
+        self.assertEqual(result, [SESSION_2])
+
+    async def test_scoped_skips_malformed_plan_content(self) -> None:
+        store = _room_store(rows=[(SESSION_1, json.dumps({"content": "oops"}))])
+        result = await _activity_session_ids([SESSION_1], "act-1", store)
+        self.assertEqual(result, [])
+
+    async def test_no_children_no_query(self) -> None:
+        store = _room_store()
+        self.assertEqual(await _activity_session_ids([], None, store), [])
+        store.db_pool.execute.assert_not_awaited()
+
+
+class TestMemberSpaceIds(unittest.IsolatedAsyncioTestCase):
+    async def test_joined_space_kept(self) -> None:
+        store = _room_store(membership=("join", "$event"))
+        self.assertEqual(await _member_space_ids([SPACE_A], USER, store), [SPACE_A])
+
+    async def test_non_member_space_dropped_silently(self) -> None:
+        store = _room_store(membership=(None, None))
+        self.assertEqual(await _member_space_ids([SPACE_A], USER, store), [])
+
+    async def test_left_space_dropped(self) -> None:
+        store = _room_store(membership=("leave", "$event"))
+        self.assertEqual(await _member_space_ids([SPACE_A], USER, store), [])
+
+    async def test_lookup_error_drops_that_space_only(self) -> None:
+        store = _room_store()
+        store.get_local_current_membership_for_user_in_room = AsyncMock(
+            side_effect=[Exception("boom"), ("join", "$event")]
+        )
+        result = await _member_space_ids([SPACE_A, SPACE_B], USER, store)
+        self.assertEqual(result, [SPACE_B])
+
+
+class TestGetActivitySessionPreviews(unittest.IsolatedAsyncioTestCase):
+    async def test_sessions_flow_into_room_preview(self) -> None:
+        store = _room_store()
+        store.db_pool.execute = AsyncMock(
+            side_effect=[
+                # children query
+                [_child_row(SPACE_A, SESSION_1, {"via": ["my.domain.name"]})],
+                # plan query
+                [_plan_row(SESSION_1, {"activity_id": "act-1"})],
+            ]
+        )
+        preview: dict[str, Any] = {SESSION_1: {"pangea.activity_plan": {}}}
+        with patch(
+            "synapse_pangea_chat.activity_session_previews."
+            "get_activity_session_previews.get_room_preview",
+            new=AsyncMock(return_value=preview),
+        ) as mock_preview:
+            result = await get_activity_session_previews(
+                [SPACE_A], None, USER, MagicMock(), store, MagicMock()
+            )
+        self.assertEqual(result, preview)
+        mock_preview.assert_awaited_once()
+        self.assertEqual(mock_preview.await_args_list[0].args[0], [SESSION_1])
+
+    async def test_no_sessions_skips_room_preview(self) -> None:
+        store = _room_store(rows=[])
+        with patch(
+            "synapse_pangea_chat.activity_session_previews."
+            "get_activity_session_previews.get_room_preview",
+            new=AsyncMock(),
+        ) as mock_preview:
+            result = await get_activity_session_previews(
+                [SPACE_A], None, USER, MagicMock(), store, MagicMock()
+            )
+        self.assertEqual(result, {})
+        mock_preview.assert_not_awaited()


### PR DESCRIPTION
## What
New `activity_session_previews` module: space-scoped session discovery returning `room_preview`-shaped data for only the activity-session child rooms of the caller's joined course spaces.

## Why
Closes #149. Server half of pangeachat/client#7982 — replaces the client-side full-hierarchy walk that missed sessions past the first hierarchy page in large courses. Design contract: [activity-session-previews.instructions.md](.github/instructions/activity-session-previews.instructions.md) (#150).

## Changes
- `GET /_synapse/client/pangea/v1/activity_session_previews?rooms=<space-csv>&activity=<opt>`
- Thin front on the `room_preview` reader (`get_room_preview` reused as-is; `room_preview` untouched): resolve direct `m.space.child` children → membership gate → `pangea.activity_plan` filter → existing preview projection.
- Membership-gated: caller must be joined to each space; non-member spaces dropped silently.
- Removed children (no valid `via`) excluded; suggestion flag ignored; plan filter reads `pangea.activity_plan` independent of `room_preview_state_event_types` config.
- Shares `room_preview`'s per-user rate limiter, cache, and reactive invalidation.

## Testing
- **Unit** (`tests/test_activity_session_previews_unit.py`, 19 tests, pass): via-validity/removed-child logic, child dedup + self-exclusion, activity scoping, malformed content, membership gating incl. per-space error isolation, composition into `get_room_preview`.
- **Integration/e2e** (`tests/test_activity_session_previews_e2e.py`, live Synapse + Postgres, pass): session-only results (chat/removed/space excluded), `?activity` scoping, `room_preview` payload shape with projected plan content, non-member space silently dropped, mixed member/non-member batch, no-param empty response, and a **110-child space returning its late-added session** (the #7982 regression, server-side).
- Neighbor suites `test_room_preview_e2e` + `test_room_preview_reactive_cache` re-run locally (module boot path shared via `PangeaChat.__init__`): pass.
- `black` / `ruff` / `mypy` clean across the package.

## Deploy Notes
None for this PR — additive endpoint, no config or ordering requirement. The client-adoption PR (pangeachat/client, upcoming) carries the server-before-client ordering and will open the `deploy-note`.
