### PR TITLE
fix(delete_room): power-level crash, 403 denials, deferred purge + design doc

### DIFF
--- a/.github/instructions/delete-room.instructions.md
+++ b/.github/instructions/delete-room.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "synapse_pangea_chat/delete_user/**,synapse_pangea_chat/export_user_data/**,synapse_pangea_chat/__init__.py,tests/test_delete_user_e2e.py,tests/test_export_user_data_e2e.py,tests/test_export_user_data_unit.py"
+---
+
+# Delete Room — Synapse Module
+
+POST /_synapse/client/pangea/v1/delete_room
+
+Deletes a room from the homeserver. Teachers and course admins reach it from the client (chat details, the chat context menu, and the delete-space dialog). Pangea-bot's space-cleanup job calls the same endpoint to retire inactive spaces.
+
+Matrix has no way to delete a room across all servers, so "delete" here means: detach the room from its parent spaces, remove every local member, and purge all local room data.
+
+### Who may delete
+
+The requester must be authenticated, a joined member of the room, and hold the room's highest power level.
+
+Ties qualify: any member at the top power level may delete. This is intentional — the bot holds admin power level in the rooms it manages, and pangea-bot's cleanup deletes through this same rule.
+
+The comparison covers every member's effective power level, including members who only hold the room's default level.
+
+A room with no power-levels state event denies the request cleanly. It must never return a server error.
+
+The client hides delete buttons from non-admins and in direct chats, but the server-side check is the authority.
+
+### What deletion does
+
+Space link cleanup, best effort. The room's child link in each parent space is removed, sent as the requester. If the requester lacks permission in a parent space, the failure is logged and deletion continues — a leftover child link in the space is accepted rather than blocking deletion.
+
+Every joined local member leaves the room. Members on other homeservers cannot be removed this way; this is accepted because deployment is effectively single-homeserver.
+
+All local room data is purged. The purge runs inside the request, so large rooms respond slowly. Accepted at current scale.
+
+Deletion does not block the room from returning through federation or re-creation — the same accepted single-homeserver risk. Because deletion is irreversible, every success is logged with the requester and room id.
+
+### Error contract
+
+Permission denials (not a member, not at the top power level) return 403.
+Malformed requests (bad JSON, missing room_id) return 400.
+Requests without a valid access token fail with the same authentication semantics as the rest of the module surface.
+Rate-limited requests return 429.
+
+### Rate limiting
+
+A per-user sliding window, configured by delete_room_requests_per_burst and delete_room_burst_duration_seconds. It is in-memory and per-process — a best-effort abuse guard, not a security boundary. The client deletes a space's children in parallel, so the configured limit must stay above the largest realistic course size or deleting a big space partially fails.
+
+### Key files
+Endpoint registration: ../../synapse_pangea_chat/__init__.py
+Handler: synapse_pangea_chat/delete_room/
+Config: synapse_pangea_chat/config.py
+Tests: tests/test_delete_room_e2e.py, tests/test_delete_room_unit.py
+Client caller: client/lib/routes/chat/chat_details/delete_room_extension.dart; bot caller: pangea_bot/synapse_admin_client/room.py (other repos, so plain paths rather than links)

--- a/.github/instructions/delete-room.instructions.md
+++ b/.github/instructions/delete-room.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "synapse_pangea_chat/delete_user/**,synapse_pangea_chat/export_user_data/**,synapse_pangea_chat/__init__.py,tests/test_delete_user_e2e.py,tests/test_export_user_data_e2e.py,tests/test_export_user_data_unit.py"
+applyTo: "synapse_pangea_chat/delete_room/**,tests/test_delete_room_e2e.py,tests/test_delete_room_unit.py"
 ---
 
 # Delete Room — Synapse Module
@@ -28,7 +28,7 @@ Space link cleanup, best effort. The room's child link in each parent space is r
 
 Every joined local member leaves the room. Members on other homeservers cannot be removed this way; this is accepted because deployment is effectively single-homeserver.
 
-All local room data is purged. The purge runs inside the request, so large rooms respond slowly. Accepted at current scale.
+All local room data is purged — but not immediately. The purge is scheduled for days later (`delete_room_purge_delay_seconds`, default 7 days) through Synapse's durable task scheduler. The delay exists so the leave events survive long enough for members' clients to sync them; an immediate purge deletes the leaves before delivery, and those clients then show the deleted room forever. Clients offline for longer than the whole window can still miss the leave — accepted, and tunable via the delay. If a local user rejoins during the window, the scheduled purge fails safe instead of deleting the room out from under them.
 
 Deletion does not block the room from returning through federation or re-creation — the same accepted single-homeserver risk. Because deletion is irreversible, every success is logged with the requester and room id.
 

--- a/synapse_pangea_chat/__init__.py
+++ b/synapse_pangea_chat/__init__.py
@@ -356,6 +356,9 @@ class PangeaChat:
         delete_room_burst_duration_seconds = config.get(
             "delete_room_burst_duration_seconds", 60
         )
+        delete_room_purge_delay_seconds = config.get(
+            "delete_room_purge_delay_seconds", 604800
+        )
 
         # --- user_activity config ---
         user_activity_requests_per_burst = config.get(
@@ -600,6 +603,7 @@ class PangeaChat:
             preview_with_code_state_event_types=preview_with_code_state_event_types,
             delete_room_requests_per_burst=delete_room_requests_per_burst,
             delete_room_burst_duration_seconds=delete_room_burst_duration_seconds,
+            delete_room_purge_delay_seconds=delete_room_purge_delay_seconds,
             user_activity_requests_per_burst=user_activity_requests_per_burst,
             user_activity_burst_duration_seconds=user_activity_burst_duration_seconds,
             user_activity_notification_bot_user_id=user_activity_notification_bot_user_id,

--- a/synapse_pangea_chat/config.py
+++ b/synapse_pangea_chat/config.py
@@ -53,6 +53,7 @@ class PangeaChatConfig:
     # --- delete_room config ---
     delete_room_requests_per_burst: int = 10
     delete_room_burst_duration_seconds: int = 60
+    delete_room_purge_delay_seconds: int = 604800  # 7 days
 
     # --- user_activity config ---
     user_activity_requests_per_burst: int = 10

--- a/synapse_pangea_chat/delete_room/cleanup_space_relationships.py
+++ b/synapse_pangea_chat/delete_room/cleanup_space_relationships.py
@@ -23,9 +23,8 @@ async def cleanup_space_relationships(
         room_id: The ID of the room being deleted
         sender_user_id: The user ID to use as the sender for the cleanup events
 
-    This function:
-    1. Removes m.space.parent events from the deleted room
-    2. Removes m.space.child events from parent spaces that reference the deleted room
+    Removes m.space.child events from parent spaces that reference the deleted
+    room. The room's own m.space.parent events go away with the purge.
     """
     try:
         # Step 1: Get all m.space.parent events from the deleted room
@@ -82,34 +81,6 @@ async def cleanup_space_relationships(
                 )
                 # Continue with other parent spaces even if one fails
                 continue
-
-        # Step 3: Remove m.space.parent events from the deleted room
-        # This happens automatically when the room is purged, but we can be explicit
-        for state_event in space_parent_events.values():
-            if state_event.type == EVENT_TYPE_M_SPACE_PARENT:
-                try:
-                    logger.info(
-                        "Removing m.space.parent event for %s from room %s",
-                        state_event.state_key,
-                        room_id,
-                    )
-                    await api.create_and_send_event_into_room(
-                        {
-                            "type": EVENT_TYPE_M_SPACE_PARENT,
-                            "state_key": state_event.state_key,
-                            "room_id": room_id,
-                            "sender": sender_user_id,
-                            "content": {},  # Empty content removes the state
-                        }
-                    )
-                except Exception as e:
-                    logger.error(
-                        "Failed to remove m.space.parent event from room %s: %s",
-                        room_id,
-                        e,
-                    )
-                    # Continue with other events even if one fails
-                    continue
 
     except Exception as e:
         logger.error(

--- a/synapse_pangea_chat/delete_room/delete_room.py
+++ b/synapse_pangea_chat/delete_room/delete_room.py
@@ -9,6 +9,7 @@ from synapse.api.errors import (
     InvalidClientTokenError,
     MissingClientTokenError,
 )
+from synapse.handlers.pagination import PURGE_ROOM_ACTION_NAME
 from synapse.http import server
 from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
@@ -41,8 +42,8 @@ class DeleteRoom(Resource):
         self._api = api
         self._config = config
         self._auth = self._api._hs.get_auth()
-        self._datastores = self._api._hs.get_datastores()
-        self._pagination_handler = self._api._hs.get_pagination_handler()
+        self._task_scheduler = self._api._hs.get_task_scheduler()
+        self._clock = self._api._hs.get_clock()
 
     def render_POST(self, request: SynapseRequest):
         defer.ensureDeferred(self._async_render_POST(request))
@@ -88,8 +89,8 @@ class DeleteRoom(Resource):
             if not is_member:
                 respond_with_json(
                     request,
-                    400,
-                    {"error": "Bad request. Not a member of the room"},
+                    403,
+                    {"error": "Forbidden. Not a member of the room"},
                     send_cors=True,
                 )
                 return
@@ -98,8 +99,8 @@ class DeleteRoom(Resource):
             if not await user_has_highest_power_level(self._api, requester_id, room_id):
                 respond_with_json(
                     request,
-                    400,
-                    {"error": "Bad request. Not the highest power level"},
+                    403,
+                    {"error": "Forbidden. Not the highest power level"},
                     send_cors=True,
                 )
 
@@ -110,16 +111,33 @@ class DeleteRoom(Resource):
 
             for user in room_members_ids:
                 try:
-                    # Try to use the module API for all users, both local and remote
+                    # Only works for local users; remote members can't be
+                    # removed from here (accepted: single-homeserver deployment)
                     await self._api.update_room_membership(
                         user, user, room_id, MEMBERSHIP_LEAVE
                     )
                 except Exception as e:
-                    logger.error(
+                    logger.warning(
                         "Failed to remove membership for %s in %s: %s", user, room_id, e
                     )
 
-            await self._pagination_handler.purge_room(room_id, force=True)
+            # Defer the purge so the leave events stay available for members'
+            # clients to sync; without force, the purge fails safe if a local
+            # user rejoins during the delay window
+            await self._task_scheduler.schedule_task(
+                PURGE_ROOM_ACTION_NAME,
+                resource_id=room_id,
+                timestamp=self._clock.time_msec()
+                + self._config.delete_room_purge_delay_seconds * 1000,
+            )
+
+            logger.info(
+                "Room %s deleted by %s (%d members removed, purge in %ds)",
+                room_id,
+                requester_id,
+                len(room_members_ids),
+                self._config.delete_room_purge_delay_seconds,
+            )
 
             respond_with_json(
                 request,

--- a/synapse_pangea_chat/delete_room/user_has_highest_power_level.py
+++ b/synapse_pangea_chat/delete_room/user_has_highest_power_level.py
@@ -7,26 +7,25 @@ async def user_has_highest_power_level(
     api: ModuleApi, user_id: str, room_id: str
 ) -> bool:
     """
-    Check if the user has the highest power level in the room.
+    Check if the user is at the room's highest power level (ties qualify).
+
+    Members not listed in `users` hold `users_default`, so the default is both
+    the unlisted user's own level and a floor for the room's highest level.
+    A room with no m.room.power_levels state event denies cleanly.
     """
-    room_member_state_events = await api.get_room_state(
+    room_state = await api.get_room_state(
         room_id=room_id,
         event_filter=[(EVENT_TYPE_M_ROOM_POWER_LEVELS, "")],
     )
-    highest_power_level = None
-    user_power_level = None
-    for state_event in room_member_state_events.values():
-        if state_event.type != EVENT_TYPE_M_ROOM_POWER_LEVELS:
-            continue
-        # At this point we can expect `state_event.content` to follow the schema defined
-        # in https://spec.matrix.org/v1.11/client-server-api/#mroompower_levels
-        users_default = state_event.content.get("users_default", 0)
-        user_power_levels = state_event.content.get("users", {})
-        for user, power_level in user_power_levels.items():
-            if user == user_id:
-                user_power_level = power_level
-            if highest_power_level is None or power_level > highest_power_level:
-                highest_power_level = power_level
-    if user_power_level is None:
-        user_power_level = users_default
+    power_levels = None
+    for state_event in room_state.values():
+        if state_event.type == EVENT_TYPE_M_ROOM_POWER_LEVELS:
+            power_levels = state_event.content
+            break
+    if power_levels is None:
+        return False
+    users_default = power_levels.get("users_default", 0)
+    user_power_levels = power_levels.get("users", {})
+    user_power_level = user_power_levels.get(user_id, users_default)
+    highest_power_level = max([users_default, *user_power_levels.values()])
     return user_power_level >= highest_power_level

--- a/tests/staging_tests/staging_tests.py
+++ b/tests/staging_tests/staging_tests.py
@@ -394,12 +394,12 @@ class StagingSmokeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 403)
 
     async def test_delete_room_non_member(self) -> None:
-        """Deleting a room user is not a member of → 400."""
+        """Deleting a room user is not a member of → 403."""
         resp = await self._post(
             "/_synapse/client/pangea/v1/delete_room",
             json={"room_id": "!nonexistent000:staging.pangea.chat"},
         )
-        self.assertEqual(resp.status, 400)
+        self.assertEqual(resp.status, 403)
 
     async def test_delete_room_missing_room_id(self) -> None:
         """Missing room_id in body → 400."""

--- a/tests/test_delete_room_e2e.py
+++ b/tests/test_delete_room_e2e.py
@@ -86,7 +86,7 @@ class TestE2E(BaseSynapseE2ETest):
                 json={"room_id": room_id},
                 headers={"Authorization": f"Bearer {tokens['user2']}"},
             )
-            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 403)
             self.assertIn("highest power level", response.json().get("error", ""))
             # Room creator deletes (should succeed)
             response = requests.post(

--- a/tests/test_delete_room_unit.py
+++ b/tests/test_delete_room_unit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from synapse_pangea_chat.config import PangeaChatConfig
+from synapse_pangea_chat.delete_room import is_rate_limited as rate_limit_module
+from synapse_pangea_chat.delete_room.is_rate_limited import is_rate_limited
+from synapse_pangea_chat.delete_room.user_has_highest_power_level import (
+    user_has_highest_power_level,
+)
+
+USER = "@teacher:my.domain.name"
+OTHER = "@student:my.domain.name"
+ROOM = "!room:my.domain.name"
+
+
+def _api_with_power_levels(content: dict | None) -> MagicMock:
+    api = MagicMock()
+    state = {}
+    if content is not None:
+        state[("m.room.power_levels", "")] = SimpleNamespace(
+            type="m.room.power_levels", content=content
+        )
+    api.get_room_state = AsyncMock(return_value=state)
+    return api
+
+
+class TestUserHasHighestPowerLevel(unittest.IsolatedAsyncioTestCase):
+    async def test_no_power_levels_event_denies(self):
+        api = _api_with_power_levels(None)
+        self.assertFalse(await user_has_highest_power_level(api, USER, ROOM))
+
+    async def test_empty_users_map_everyone_at_default_qualifies(self):
+        api = _api_with_power_levels({"users_default": 0, "users": {}})
+        self.assertTrue(await user_has_highest_power_level(api, USER, ROOM))
+
+    async def test_tie_at_top_qualifies(self):
+        api = _api_with_power_levels({"users": {USER: 100, OTHER: 100}})
+        self.assertTrue(await user_has_highest_power_level(api, USER, ROOM))
+
+    async def test_below_top_denies(self):
+        api = _api_with_power_levels({"users": {USER: 50, OTHER: 100}})
+        self.assertFalse(await user_has_highest_power_level(api, USER, ROOM))
+
+    async def test_unlisted_requester_below_listed_admin_denies(self):
+        api = _api_with_power_levels({"users_default": 0, "users": {OTHER: 100}})
+        self.assertFalse(await user_has_highest_power_level(api, USER, ROOM))
+
+    async def test_listed_requester_below_users_default_denies(self):
+        api = _api_with_power_levels({"users_default": 100, "users": {USER: 50}})
+        self.assertFalse(await user_has_highest_power_level(api, USER, ROOM))
+
+
+class TestIsRateLimited(unittest.TestCase):
+    def setUp(self):
+        rate_limit_module.request_log.clear()
+        self.config = PangeaChatConfig(
+            delete_room_requests_per_burst=3,
+            delete_room_burst_duration_seconds=60,
+        )
+
+    def test_allows_up_to_burst_then_limits(self):
+        with patch.object(rate_limit_module.time, "time", return_value=1000.0):
+            for _ in range(3):
+                self.assertFalse(is_rate_limited(USER, self.config))
+            self.assertTrue(is_rate_limited(USER, self.config))
+
+    def test_limit_is_per_user(self):
+        with patch.object(rate_limit_module.time, "time", return_value=1000.0):
+            for _ in range(3):
+                is_rate_limited(USER, self.config)
+            self.assertFalse(is_rate_limited(OTHER, self.config))
+
+    def test_window_expiry_allows_again(self):
+        with patch.object(rate_limit_module.time, "time", return_value=1000.0):
+            for _ in range(3):
+                is_rate_limited(USER, self.config)
+            self.assertTrue(is_rate_limited(USER, self.config))
+        with patch.object(rate_limit_module.time, "time", return_value=1061.0):
+            self.assertFalse(is_rate_limited(USER, self.config))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Harden the delete_room module: fix the power-level check crash, return 403 for permission denials, defer the room purge so leave events reach clients, add audit logging, and add the module's design doc.

## Why

Closes #159, Closes #161.

Design decisions (authorization rule, error contract, deferred purge) were agreed in chat on 2026-08-11; the design lives in [delete-room.instructions.md](.github/instructions/delete-room.instructions.md) — see "Who may delete", "What deletion does", and "Error contract" rather than restating here. The purge is now scheduled through Synapse's durable task scheduler after `delete_room_purge_delay_seconds` (new config key, default 7 days) instead of running in-request; scheduling uses the no-force purge so a local rejoin during the window fails safe.

## Testing

- Unit: new `tests/test_delete_room_unit.py` (9 tests — power-level edge cases incl. the two crash paths, rate-limiter window) — pass.
- Integration: `tests/test_delete_room_e2e.py` (real Synapse + Postgres) — both tests pass with the 403 contract and deferred purge. Note: these tests bind :8008 and collide with a running `pangea-local-synapse` docker container ("HMAC incorrect" at registration) — stop the container for the run.
- Local stack end-to-end: deployed the module into the local docker Synapse; verified 403 both denial paths, 200 delete, audit log line, `purge_room` task scheduled 7 days out in `scheduled_tasks`, and — the #161 case — a client offline during deletion receives the room under `rooms.leave` when syncing from a pre-deletion token. UI flow (chat context menu → Delete → confirm) exercised via the web client against local Synapse.
- Staging smoke tests: `test_delete_room_non_member` updated 400 → 403; will pass after this deploys to staging (staging currently returns 400).

## Deploy Notes

None — the new config key defaults to 7 days; no env or Ansible changes required.