### PR TITLE
feat(delete_room): mark deletion leave events with pangea.room_deleted

### DIFF
--- a/.github/instructions/delete-room.instructions.md
+++ b/.github/instructions/delete-room.instructions.md
@@ -26,7 +26,7 @@ The client hides delete buttons from non-admins and in direct chats, but the ser
 
 Space link cleanup, best effort. The room's child link in each parent space is removed, sent as the requester. If the requester lacks permission in a parent space, the failure is logged and deletion continues — a leftover child link in the space is accepted rather than blocking deletion.
 
-Every joined local member leaves the room. Members on other homeservers cannot be removed this way; this is accepted because deployment is effectively single-homeserver.
+Every joined local member leaves the room. Each leave is a self-leave (sender is the member) whose content carries `"pangea.room_deleted": true` and a fixed English `reason` — the marker is how clients tell "this room was deleted" apart from a voluntary leave, which is otherwise byte-identical (a kick is already distinguishable by its sender). Delivery of the marker is only as reliable as delivery of the leave itself (see the purge delay below). Members on other homeservers cannot be removed this way; this is accepted because deployment is effectively single-homeserver.
 
 All local room data is purged — but not immediately. The purge is scheduled for days later (`delete_room_purge_delay_seconds`, default 7 days) through Synapse's durable task scheduler. The delay exists so the leave events survive long enough for members' clients to sync them; an immediate purge deletes the leaves before delivery, and those clients then show the deleted room forever. Clients offline for longer than the whole window can still miss the leave — accepted, and tunable via the delay. If a local user rejoins during the window, the scheduled purge fails safe instead of deleting the room out from under them.
 

--- a/synapse_pangea_chat/delete_room/constants.py
+++ b/synapse_pangea_chat/delete_room/constants.py
@@ -5,6 +5,11 @@ MEMBERSHIP_INVITE = "invite"  # existing membership value
 MEMBERSHIP_JOIN = "join"  # existing membership value
 MEMBERSHIP_LEAVE = "leave"  # existing membership valu
 
+# Marker added to the self-leave events sent on room deletion so clients can
+# distinguish "the room was deleted" from a voluntary leave (client#8237)
+ROOM_DELETED_CONTENT_KEY = "pangea.room_deleted"
+ROOM_DELETED_REASON = "This space has been deleted"
+
 # https://spec.matrix.org/v1.11/client-server-api/#mroompower_levels
 EVENT_TYPE_M_ROOM_POWER_LEVELS = "m.room.power_levels"
 

--- a/synapse_pangea_chat/delete_room/delete_room.py
+++ b/synapse_pangea_chat/delete_room/delete_room.py
@@ -20,7 +20,11 @@ from twisted.web.resource import Resource
 from synapse_pangea_chat.delete_room.cleanup_space_relationships import (
     cleanup_space_relationships,
 )
-from synapse_pangea_chat.delete_room.constants import MEMBERSHIP_LEAVE
+from synapse_pangea_chat.delete_room.constants import (
+    MEMBERSHIP_LEAVE,
+    ROOM_DELETED_CONTENT_KEY,
+    ROOM_DELETED_REASON,
+)
 from synapse_pangea_chat.delete_room.extract_body_json import extract_body_json
 from synapse_pangea_chat.delete_room.get_room_members import get_room_members
 from synapse_pangea_chat.delete_room.is_rate_limited import is_rate_limited
@@ -114,7 +118,14 @@ class DeleteRoom(Resource):
                     # Only works for local users; remote members can't be
                     # removed from here (accepted: single-homeserver deployment)
                     await self._api.update_room_membership(
-                        user, user, room_id, MEMBERSHIP_LEAVE
+                        user,
+                        user,
+                        room_id,
+                        MEMBERSHIP_LEAVE,
+                        content={
+                            "reason": ROOM_DELETED_REASON,
+                            ROOM_DELETED_CONTENT_KEY: True,
+                        },
                     )
                 except Exception as e:
                     logger.warning(

--- a/tests/test_delete_room_e2e.py
+++ b/tests/test_delete_room_e2e.py
@@ -106,6 +106,20 @@ class TestE2E(BaseSynapseE2ETest):
                 joined_rooms = resp.json().get("joined_rooms", [])
                 self.assertEqual(len(joined_rooms), 0)
 
+            # Assert the leave events carry the room-deleted marker so clients
+            # can tell deletion apart from a voluntary leave (client#8237)
+            for remove_user in ["user2", "user3"]:
+                member_url = f"http://localhost:8008/_matrix/client/v3/rooms/{room_id}/state/m.room.member/@{remove_user}:my.domain.name"
+                resp = requests.get(
+                    member_url,
+                    headers={"Authorization": f"Bearer {tokens[remove_user]}"},
+                )
+                self.assertEqual(resp.status_code, 200)
+                content = resp.json()
+                self.assertEqual(content.get("membership"), "leave")
+                self.assertTrue(content.get("pangea.room_deleted"))
+                self.assertEqual(content.get("reason"), "This space has been deleted")
+
             # "roomadmin" creates another private room and invite anotheradmin
             room_id = await self.create_private_room(admin_token)
             for admin in ["anotheradmin"]:


### PR DESCRIPTION
## What

Each member's self-leave on room deletion now carries `"pangea.room_deleted": true` and a fixed English `reason` in the event content, so clients can distinguish "this room was deleted" from a voluntary leave (they are otherwise byte-identical; a kick is already distinguishable by sender). Client consumer: pangeachat/client#8274 (closes pangeachat/client#8237).

**Stacked on #160** — the deferred purge is what makes the marked leave reliably reach members' sync; this PR should merge into that branch (or rebase onto main after #160 lands).

## Doc note

Adds one sentence to `delete-room.instructions.md` ("What deletion does") describing the marker. Per the instructions-editing invariant this needs explicit sign-off in discussion, not just PR review — flagging rather than merging silently.

## Testing

- `tests/test_delete_room_e2e.py` extended: after deletion, each removed member's leave state carries the marker + reason. Both e2e tests pass locally (real Synapse + Postgres; needs `LC_ALL` set and port 8008 free).
- `tests/test_delete_room_unit.py` (9 tests) — pass. black/ruff/mypy clean.
- Local stack: module deployed into pangea-local-synapse; full client UI delete flow produced marked leave events on the wire and drove the client dialog end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)