### PR TITLE
fix(email_invite): emit the short-code join link in course invite emails

### DIFF
--- a/synapse_pangea_chat/email_invite/build_join_url.py
+++ b/synapse_pangea_chat/email_invite/build_join_url.py
@@ -1,0 +1,20 @@
+"""Shared builder for the course join link handed out in emails."""
+
+from __future__ import annotations
+
+
+def build_join_url(app_base_url: str, access_code: str) -> str:
+    """Join link for a course space, from its access code.
+
+    The link is the bare short code ``<app>/<code>`` — that path *is* the app
+    URL on web and native alike, with no redirect hop. The older
+    ``/#/join_with_link?classcode=`` spelling is retired: the client has no such
+    route, and web runs a path URL strategy, so a fragment is not part of the
+    route at all and such a link lands on the world map.
+
+    Built on the environment's app host from ``app_base_url`` (ansible sets it
+    per env: ``app.pangea.chat`` in prod, ``app.staging.pangea.chat`` on
+    staging), never a hardcoded host — a staging course must not hand out a
+    prod link.
+    """
+    return f"{app_base_url.rstrip('/')}/{access_code}"

--- a/synapse_pangea_chat/email_invite/create_course_space.py
+++ b/synapse_pangea_chat/email_invite/create_course_space.py
@@ -27,6 +27,7 @@ from synapse.types import create_requester
 from twisted.internet import defer
 from twisted.web.resource import Resource
 
+from synapse_pangea_chat.email_invite.build_join_url import build_join_url
 from synapse_pangea_chat.room_code.constants import (
     ACCESS_CODE_JOIN_RULE_CONTENT_KEY,
     ADMIN_ACCESS_CODE_JOIN_RULE_CONTENT_KEY,
@@ -86,19 +87,6 @@ def build_course_plan_content(
     if isinstance(target_language, str) and target_language.strip():
         content["l2"] = target_language.strip()
     return content
-
-
-def build_admin_join_url(app_base_url: str, access_code: str) -> str:
-    """Admin join link for a newly created course space.
-
-    The external form is the CloudFront short code ``<app>/<code>`` — a 302 to
-    the client's ``/join_with_link?classcode=`` route, which the client is the
-    sole producer of (see deep-linking.instructions.md). Built on the
-    environment's app host from ``app_base_url`` (ansible sets it per env:
-    ``app.pangea.chat`` in prod, ``app.staging.pangea.chat`` on staging), never
-    a hardcoded host — a staging course must not hand out a prod link.
-    """
-    return f"{app_base_url.rstrip('/')}/{access_code}"
 
 
 class CreateCourseSpace(Resource):
@@ -247,8 +235,8 @@ class CreateCourseSpace(Resource):
                     logger.warning(f"Failed to set room avatar: {e}")
 
             # Build admin join URL — short code on the env's app host, never a
-            # hardcoded host (see build_admin_join_url).
-            admin_join_url = build_admin_join_url(self._config.app_base_url, admin_code)
+            # hardcoded host (see build_join_url).
+            admin_join_url = build_join_url(self._config.app_base_url, admin_code)
 
             # TODO: Send invite email to teacher via invite_by_email
             # (placeholder — invite_by_email endpoint is a separate session)

--- a/synapse_pangea_chat/email_invite/invite_by_email.py
+++ b/synapse_pangea_chat/email_invite/invite_by_email.py
@@ -25,6 +25,7 @@ from synapse.module_api import ModuleApi
 from twisted.internet import defer
 from twisted.web.resource import Resource
 
+from synapse_pangea_chat.email_invite.build_join_url import build_join_url
 from synapse_pangea_chat.room_code.constants import (
     ACCESS_CODE_JOIN_RULE_CONTENT_KEY,
     EVENT_TYPE_M_ROOM_JOIN_RULES,
@@ -150,8 +151,7 @@ class InviteByEmail(Resource):
                 )
                 return
 
-            base = self._config.app_base_url.rstrip("/")
-            join_url = f"{base}/#/join_with_link?classcode={access_code}"
+            join_url = build_join_url(self._config.app_base_url, access_code)
 
             # Send emails
             emailed: List[str] = []

--- a/tests/test_build_join_url_unit.py
+++ b/tests/test_build_join_url_unit.py
@@ -1,0 +1,76 @@
+"""Unit tests for the course join link the server emails out.
+
+The link is the only way an invited learner reaches the course, and a wrong
+shape fails silently: the app boots, lands on the world map, and nothing says
+the join was dropped. So the external form is pinned exactly, and pinned once
+for every emitter — the bug behind these tests was two emitters building the
+same URL by hand, one migrated to the short code and one left on the retired
+``/#/join_with_link?classcode=`` spelling.
+"""
+
+import pathlib
+import unittest
+
+import synapse_pangea_chat
+from synapse_pangea_chat.email_invite.build_join_url import build_join_url
+
+
+class TestBuildJoinUrl(unittest.TestCase):
+    def test_uses_the_configured_app_host_not_a_hardcoded_one(self) -> None:
+        """The host follows ``app_base_url`` (ansible sets it per env).
+
+        The bug this pins: a hardcoded ``pangea.chat`` handed every staging
+        course a production join link. Staging config resolves to the staging
+        app host and prod to the prod one.
+        """
+        self.assertEqual(
+            build_join_url("https://app.staging.pangea.chat", "04wpy5e"),
+            "https://app.staging.pangea.chat/04wpy5e",
+        )
+        self.assertEqual(
+            build_join_url("https://app.pangea.chat", "abc123x"),
+            "https://app.pangea.chat/abc123x",
+        )
+
+    def test_emits_the_short_code_form_not_the_classcode_route(self) -> None:
+        """External form is the bare short code ``<app>/<code>`` — the one shape
+        the client routes — not the retired ``/#/join_with_link?classcode=``."""
+        url = build_join_url("https://app.pangea.chat", "xyz789q")
+
+        self.assertNotIn("join_with_link", url)
+        self.assertNotIn("classcode", url)
+        self.assertTrue(url.endswith("/xyz789q"))
+
+    def test_trailing_slash_on_base_is_not_doubled(self) -> None:
+        self.assertEqual(
+            build_join_url("https://app.pangea.chat/", "code42x"),
+            "https://app.pangea.chat/code42x",
+        )
+
+
+class TestNoModuleBuildsTheRetiredRoute(unittest.TestCase):
+    def test_retired_spelling_appears_nowhere_in_the_module(self) -> None:
+        """No module hand-rolls the retired link shape.
+
+        Both emitters go through ``build_join_url``, so fixing the format in one
+        place fixes it everywhere — but only as long as nobody writes the old
+        spelling out again. That is exactly how the course-invite email stayed
+        broken after the sibling emitter was migrated.
+        """
+        package_root = pathlib.Path(synapse_pangea_chat.__file__).parent
+        # The helper itself names the retired shape, to say it is retired.
+        helper = package_root / "email_invite" / "build_join_url.py"
+        offenders = [
+            str(path.relative_to(package_root))
+            for path in package_root.rglob("*.py")
+            if path != helper
+            and (
+                "join_with_link" in path.read_text() or "classcode" in path.read_text()
+            )
+        ]
+
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_course_space_unit.py
+++ b/tests/test_create_course_space_unit.py
@@ -12,7 +12,6 @@ import unittest
 from typing import Any
 
 from synapse_pangea_chat.email_invite.create_course_space import (
-    build_admin_join_url,
     build_course_plan_content,
 )
 from synapse_pangea_chat.public_courses.get_public_courses import (
@@ -135,39 +134,6 @@ class TestCatalogReadsWhatWeWrite(unittest.TestCase):
         content = build_course_plan_content("", "es")
 
         self.assertIsNone(extract_plan_id(content))
-
-
-class TestBuildAdminJoinUrl(unittest.TestCase):
-    def test_uses_the_configured_app_host_not_a_hardcoded_one(self) -> None:
-        """The host follows ``app_base_url`` (ansible sets it per env).
-
-        The bug this pins: a hardcoded ``pangea.chat`` handed every staging
-        course a production join link. Staging config resolves to the staging
-        app host and prod to the prod one.
-        """
-        self.assertEqual(
-            build_admin_join_url("https://app.staging.pangea.chat", "04wpy5e"),
-            "https://app.staging.pangea.chat/04wpy5e",
-        )
-        self.assertEqual(
-            build_admin_join_url("https://app.pangea.chat", "abc123x"),
-            "https://app.pangea.chat/abc123x",
-        )
-
-    def test_emits_the_short_code_form_not_the_classcode_route(self) -> None:
-        """External form is ``<app>/<code>`` — the CloudFront 302 source — not
-        the client's internal ``/#/join_with_link?classcode=`` spelling."""
-        url = build_admin_join_url("https://app.pangea.chat", "xyz789q")
-
-        self.assertNotIn("join_with_link", url)
-        self.assertNotIn("classcode", url)
-        self.assertTrue(url.endswith("/xyz789q"))
-
-    def test_trailing_slash_on_base_is_not_doubled(self) -> None:
-        self.assertEqual(
-            build_admin_join_url("https://app.pangea.chat/", "code42x"),
-            "https://app.pangea.chat/code42x",
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Course invite emails now link to `{app_base_url}/{access_code}` — the one join-link shape the client routes — via a `build_join_url` helper both email emitters share.

## Why

Closes #164

`invite_by_email` built `{base}/#/join_with_link?classcode={code}`: a route the client does not have, and on web the fragment isn't part of the route at all, so the link opened the world map and the invite went nowhere. The sibling emitter (`create_course_space`) had already been migrated to the short-code form; this one hadn't. Both now call the same helper, so there is no second place for the format to drift — pinned by a test asserting no module in the package spells the retired route.

Link shape is owned by [joining-courses.instructions.md](https://github.com/pangeachat/client/blob/main/.github/instructions/joining-courses.instructions.md) Route 1.

## Testing

- Unit: `test_build_join_url_unit.py` (host follows `app_base_url`, short-code form, trailing slash, no module hand-rolls the retired spelling) — the `build_admin_join_url` tests moved here with the helper.
- Integration: full local suite, 337 tests, OK (`python -m unittest discover -s tests -t .`), including `test_create_course_space_e2e` which loads the module under a real Synapse.
- black / ruff / mypy clean.
- The email itself is not covered locally — `invite_by_email` needs SMTP config the local test homeserver doesn't have, so the rendered link goes to staging QA per the issue's TO TEST.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)